### PR TITLE
Fix UTF-8 exception in santizing body

### DIFF
--- a/lib/sup/modes/edit-message-mode.rb
+++ b/lib/sup/modes/edit-message-mode.rb
@@ -618,6 +618,7 @@ protected
 private
 
   def sanitize_body body
+    body.force_encoding 'UTF-8' if body.methods.include?(:encoding)
     body.gsub(/^From /, ">From ")
   end
 


### PR DESCRIPTION
This (old) patch looks fair, but I don't have enough experience with ruby to know if there might be unexpected side effects of the force encoding.

Anyone else know?
