### PR TITLE
Rakefile: Require sup-* from relative dir

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,8 +31,8 @@ end
 
 $:.push "lib"
 require 'rubygems'
-require "sup-files"
-require "sup-version"
+require_relative "sup-files"
+require_relative "sup-version"
 require 'rake/gempackagetask.rb'
 
 spec = Gem::Specification.new do |s|


### PR DESCRIPTION
As far as I can tell, require_relative is not present in ruby 1.8, so I'm not sure this change should go ahead as it is
