### PR TITLE
Require psych in Rakefile to avoid syck error when compiling gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,6 +30,7 @@ task :upload_report do |t|
 end
 
 $:.push "lib"
+require 'psych'
 require 'rubygems'
 require "sup-files"
 require "sup-version"


### PR DESCRIPTION
From memory I'm not sure psych is available in ruby 1.8. If so this should at least be wrapped in a version check.
