### PR TITLE
Move startup hook before sent/draft source check.

### DIFF
--- a/bin/sup
+++ b/bin/sup
@@ -171,6 +171,8 @@ begin
   trap("TERM") { |x| $die = true }
   trap("WINCH") { |x| BufferManager.sigwinch_happened! }
 
+  HookManager.run "startup"
+
   if(s = Redwood::SourceManager.source_for DraftManager.source_name)
     DraftManager.source = s
   else
@@ -184,7 +186,6 @@ begin
     Redwood::SourceManager.add_source SentManager.default_source
   end
 
-  HookManager.run "startup"
   Redwood::Keymap.run_hook global_keymap
 
   debug "starting curses"


### PR DESCRIPTION
From original commit message:

> Placing the startup hook in front of the logic to select draft and sent sources gives the user control to influence this selection process.

I wonder if this might break other peoples start up hooks if they required DraftManager or SentManager, or wanted to modify them.
