### PR TITLE
Add new hook 'gpg-expand-keys'

### DIFF
--- a/lib/sup/crypto.rb
+++ b/lib/sup/crypto.rb
@@ -41,6 +41,20 @@ from_key: the key that generated the signature (class is GPGME::Key)
 Return value: an array of lines of output
 EOS
 
+  HookManager.register "gpg-expand-keys", <<EOS
+Runs when the list of encryption recipients is created, allowing you to
+replace a recipient with one or more GPGME recipients. For example, you could
+replace the email address of a mailing list with the key IDs that belong to
+the recipients of that list. This is essentially what GPG groups do, which
+are not supported by GPGME.
+
+Variables:
+recipients: an array of recipients of the current email
+
+Return value: an array of recipients (email address or GPG key ID) to encrypt
+the email for
+EOS
+
   def initialize
     @mutex = Mutex.new
 
@@ -137,7 +151,7 @@ EOS
     gpg_opts = HookManager.run("gpg-options",
                                {:operation => "encrypt", :options => gpg_opts}) || gpg_opts
     recipients = to + [from]
-
+    recipients = HookManager.run("gpg-expand-keys", { :recipients => recipients }) || recipients
     begin
       cipher = GPGME.encrypt(recipients, format_payload(payload), gpg_opts)
     rescue GPGME::Error => exc


### PR DESCRIPTION
sup does not support GPG groups, since GPGME ignores group definitions in gpg.conf by design. Therefore, there is no way e.g. to send encrypted mails to mailing lists using GPG  groups.

If a gpg.conf contains group definitions like this:

``` shell
group <foo@example.com>=KEYID001
group <foo@example.com>=KEYID002
group <bar@example.com>=KEYID001
group <bar@example.com>=KEYID002
group <bar@example.com>=KEYID003
```

When a mail is sent to bar@example.com, it should be encrypted for KEYID001, KEYID002 and KEYID003.

The new hook receives the list of current recipients (bar@example.com in the case above)  and allows the user to swap recipients with other email addresses or key IDs. A simple hook to add group support could look like this:

``` ruby
lookup_table = {}

`gpg --with-colons --list-config group 2> /dev/null`.each_line do |line|
  email_and_keys = line.split(':')[2..3]
  lookup_table[email_and_keys[0].gsub(/[<>]/, '')] = email_and_keys[1].strip.split(';')
end

recipients.map { |r| lookup_table.has_key?(r) ? lookup_table[r] : r }.flatten
```
