### PR TITLE
Convert use of Rake::GemPackageTask to Gem::PackageTask

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,6 @@ $:.push "lib"
 require 'rubygems'
 require "sup-files"
 require "sup-version"
-require 'rake/gempackagetask.rb'
 
 require 'rubygems/package_task'
 


### PR DESCRIPTION
Rake::GemPackageTask is deprecated, update to Gem::PackageTask
