### PR TITLE
Use a seemingly more maintained fork of xapian-full

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,7 +53,7 @@ spec = Gem::Specification.new do |s|
   s.files = SUP_FILES
   s.executables = SUP_EXECUTABLES
 
-  s.add_dependency "xapian-full", ">= 1.2.1"
+  s.add_dependency "xapian-full-alaveteli", "~> 1.2"
   s.add_dependency "ncursesw"
   s.add_dependency "rmail", ">= 0.17"
   s.add_dependency "highline"


### PR DESCRIPTION
Hi,

I just found in the sup-devel mailing list that this project is still maintained here. I'm a frustrated Thunderbird user and webmail is just not my thing. I'd really like to see project sup come back in good shape and become a user(or even better, a committer).

Doing `gem i xapian-full` on my Archlinux system just fails with this log: https://gist.github.com/5long/5213393 This patch makes sup uses a fork of xapian-full which works.

To be clear, this change alone doesn't make sup gem-i-installable for me. I just got stuck on another error when doing `rake gem`. But this patch is worth reviewing on its own, I guess.
