### PR TITLE
Require 'iconv' before patching it

### DIFF
--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -5,6 +5,7 @@ require 'pathname'
 require 'set'
 require 'enumerator'
 require 'benchmark'
+require 'iconv'
 
 ## time for some monkeypatching!
 class Symbol


### PR DESCRIPTION
Reopening of #11.

Doing `rake gem` raises exception `superclass mismatch for class Iconv` on Ruby 1.9.3-p392. Thus this patch.
