### PR TITLE
sup-config: call to_s() on user input

### DIFF
--- a/bin/sup-config
+++ b/bin/sup-config
@@ -24,7 +24,7 @@ def axe q, default=nil
   else
     ask "#{q}: "
   end
-  ans.empty? ? default : ans
+  ans.empty? ? default : ans.to_s
 end
 
 def axe_yes q, default="n"


### PR DESCRIPTION
Highline seems to use its own string wrapper for data entered by the
user. When converting to yaml, the value is annotated with
'!str:HighLine::String', which leads to errors when starting sup or
sup-sync.

Fixes issue #28
