### PR TITLE
Allow builds on 2.0 fail for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,7 @@ before_install:
 gemfile: Gemfile.ci
 
 script: bundle exec rake travis
+
+matrix:
+  allow_failures:
+    - rvm: 2.0.0


### PR DESCRIPTION
Sup2 is not started yet. Let's make Travis less noisy.

Relevant docs: http://about.travis-ci.org/docs/user/build-configuration/#Rows-That-are-Allowed-To-Fail
