### PR TITLE
Remove rbconfig warning

### DIFF
--- a/bin/sup
+++ b/bin/sup
@@ -117,6 +117,7 @@ end
 ##
 ## BSD users: if libc.so.6 is not found, try installing compat6x.
 require 'dl/import'
+require 'rbconfig'
 module LibC
   extend DL.const_defined?(:Importer) ? DL::Importer : DL::Importable
   setlocale_lib = case RbConfig::CONFIG['arch']

--- a/lib/sup/message-chunks.rb
+++ b/lib/sup/message-chunks.rb
@@ -1,4 +1,5 @@
 require 'tempfile'
+require 'rbconfig'
 
 ## Here we define all the "chunks" that a message is parsed
 ## into. Chunks are used by ThreadViewMode to render a message. Chunks


### PR DESCRIPTION
Use `RbConfig` instead of `Config` to remove some warnings since I'm a programmer who can't stand warnings. Also, explicitly `require "rbconfig"` module to ensure it works.
