### PR TITLE
Fix error when a source has no labels

### DIFF
--- a/lib/sup/source.rb
+++ b/lib/sup/source.rb
@@ -160,7 +160,7 @@ module SerializeLabelsNicely
   end
 
   def after_unmarshal!
-    @labels = Set.new(@labels.map { |s| s.to_sym })
+    @labels = Set.new(@labels.to_a.map { |s| s.to_sym })
   end
 end
 


### PR DESCRIPTION
Turn a nil object into [] before playing with it.
