### PR TITLE
Fix search-for-next function when using Ruby 1.9

### DIFF
--- a/lib/sup/buffer.rb
+++ b/lib/sup/buffer.rb
@@ -271,7 +271,7 @@ EOS
 
   def handle_input c
     if @focus_buf
-      if @focus_buf.mode.in_search? && c != CONTINUE_IN_BUFFER_SEARCH_KEY[0]
+      if @focus_buf.mode.in_search? && c != CONTINUE_IN_BUFFER_SEARCH_KEY.ord
         @focus_buf.mode.cancel_search!
         @focus_buf.mark_dirty
       end


### PR DESCRIPTION
The use of the 'n' key to search for the next occurrence
of a string stopped working when running sup in Ruby 1.9.
This simple patch fixes that problem.
