### PR TITLE
Added config item :no_poll_flashing to prevent sup from flashing all the time

### DIFF
--- a/lib/sup/hook.rb
+++ b/lib/sup/hook.rb
@@ -19,6 +19,10 @@ class HookManager
       end
     end
 
+    def flash s
+      BufferManager.flash s
+    end
+
     def log s
       info "hook[#@__name]: #{s}"
     end


### PR DESCRIPTION
This patch adds a configuration item to prevent sup from flashing messages all the time. This avoids the distraction when working in other windows, and allows for a tty manager like gnu screen to watch the window for updates to alert the user without triggering every few minutes.

(When adding new configuration items, whose reponsibility is it to update the documentation, and if that's me, how and where do I update this?)
