### PR TITLE
Accept UTF8 as UTF-8 and test encoding with fallback to UTF-8

### DIFF
--- a/lib/sup.rb
+++ b/lib/sup.rb
@@ -322,6 +322,16 @@ else
   $encoding = "UTF-8"
 end
 
+# test encoding
+teststr = "test"
+teststr.encode('UTF-8')
+begin
+  teststr.encode($encoding)
+rescue Encoding::ConverterNotFoundError
+  warn "locale encoding is invalid, defaulting to utf-8"
+  $encoding = "UTF-8"
+end
+
 require "sup/buffer"
 require "sup/keymap"
 require "sup/mode"


### PR DESCRIPTION
Fixes #71 (tested together with #72).

(Breaks Ruby 1.8)
