### PR TITLE
Allow thread index view to sort oldest first

### DIFF
--- a/bin/sup
+++ b/bin/sup
@@ -231,7 +231,7 @@ begin
   end
 
   if $opts[:search]
-    SearchResultsMode.spawn_from_query $opts[:search]
+    SearchResultsMode.spawn_from_query $opts[:search], true
   end
 
   until Redwood::exceptions.nonempty? || $die
@@ -301,11 +301,11 @@ begin
         if query.empty?
           bm.spawn_unless_exists("Saved searches") { SearchListMode.new }
         else
-          SearchResultsMode.spawn_from_query query
+          SearchResultsMode.spawn_from_query query, true
         end
       end
     when :search_unread
-      SearchResultsMode.spawn_from_query "is:unread"
+      SearchResultsMode.spawn_from_query "is:unread", InboxMode.newest_first
     when :list_labels
       labels = LabelManager.all_labels.map { |l| LabelManager.string_for l }
       labels = labels.each { |l| l.force_encoding 'UTF-8' if l.methods.include?(:encoding) }

--- a/lib/sup/modes/inbox_mode.rb
+++ b/lib/sup/modes/inbox_mode.rb
@@ -10,10 +10,19 @@ class InboxMode < ThreadIndexMode
     k.add :refine_search, "Refine search", '|'
   end
 
+  def self.newest_first
+    if !$config[:inbox_newest_first].nil?
+      $config[:inbox_newest_first]
+    else
+      true
+    end
+  end
+
   def initialize
     super [:inbox, :sent, :draft], { :label => :inbox, :skip_killed => true }
     raise "can't have more than one!" if defined? @@instance
     @@instance = self
+    @newest_first = InboxMode.newest_first
   end
 
   def is_relevant? m; (m.labels & [:spam, :deleted, :killed, :inbox]) == Set.new([:inbox]) end
@@ -22,7 +31,7 @@ class InboxMode < ThreadIndexMode
     text = BufferManager.ask :search, "refine inbox with query: "
     return unless text && text !~ /^\s*$/
     text = "label:inbox -label:spam -label:deleted " + text
-    SearchResultsMode.spawn_from_query text
+    SearchResultsMode.spawn_from_query text, @newest_first
   end
 
   ## label-list-mode wants to be able to raise us if the user selects

--- a/lib/sup/modes/search_results_mode.rb
+++ b/lib/sup/modes/search_results_mode.rb
@@ -1,9 +1,10 @@
 module Redwood
 
 class SearchResultsMode < ThreadIndexMode
-  def initialize query
+  def initialize query, newest_first
     @query = query
     super [], query
+    @newest_first = newest_first
   end
 
   register_keymap do |k|
@@ -14,7 +15,7 @@ class SearchResultsMode < ThreadIndexMode
   def refine_search
     text = BufferManager.ask :search, "refine query: ", (@query[:text] + " ")
     return unless text && text !~ /^\s*$/
-    SearchResultsMode.spawn_from_query text
+    SearchResultsMode.spawn_from_query text, @newest_first
   end
 
   def save_search
@@ -38,12 +39,12 @@ class SearchResultsMode < ThreadIndexMode
   ## the message, and search against it to see if i have > 0 results,
   ## but that seems pretty insane.
 
-  def self.spawn_from_query text
+  def self.spawn_from_query text, newest_first
     begin
       query = Index.parse_query(text)
       return unless query
       short_text = text.length < 20 ? text : text[0 ... 20] + "..."
-      mode = SearchResultsMode.new query
+      mode = SearchResultsMode.new query, newest_first
       BufferManager.spawn "search: \"#{short_text}\"", mode
       mode.load_threads :num => mode.buffer.content_height
     rescue Index::ParseError => e


### PR DESCRIPTION
And while we're at it, here is another patch that has been lying around in my local working copy for a year or so.

This is basically the original patch by Keith Packard, adapted to the
current code base, but with one little change in thread-index-mode: the
list of threads must be reversed when newest_first is not set.

To activate it, put this in your config.yaml

```
:inbox_newest_first: false
```

See http://article.gmane.org/gmane.mail.sup.general/2757

Original commit message:

This allows the thread index view to present oldest messages first
instead of always presenting newer messages at the top of the list.
This can be toggled using the 'o' key.

A config file option :inbox_newest_first controls whether this is
turned on by default when viewing the inbox

Refine searches inherit the order from the originating thread index.
