### PR TITLE
Get rid of gettext

### DIFF
--- a/lib/sup.rb
+++ b/lib/sup.rb
@@ -4,7 +4,7 @@ YAML::ENGINE.yamler = 'psych'
 require 'zlib'
 require 'thread'
 require 'fileutils'
-require 'gettext'
+require 'locale'
 require 'curses'
 require 'rmail'
 begin

--- a/sup.gemspec
+++ b/sup.gemspec
@@ -50,7 +50,7 @@ SUP: Please run `sup-psych-ify-config-files` to migrate from 0.13 to 0.14
     s.add_dependency "trollop", ">= 1.12"
     s.add_dependency "lockfile"
     s.add_dependency "mime-types", "~> 1"
-    s.add_dependency "gettext"
+    s.add_dependency "locale", "~> 2.0"
     s.add_dependency "chronic", "~> 0.9", ">= 0.9.1"
 
     s.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Sup actually only needs the locale gem, which is a dependency of gettext.
