### PR TITLE
Update message.rb

### DIFF
--- a/lib/sup/message.rb
+++ b/lib/sup/message.rb
@@ -540,7 +540,9 @@ private
   def inline_gpg_to_chunks body, encoding_to, encoding_from
     lines = body.split("\n")
     gpg = lines.between(GPG_SIGNED_START, GPG_SIGNED_END)
-    if !gpg.empty?
+    # between does not check if GPG_END actually exists
+    # Reference: http://permalink.gmane.org/gmane.mail.sup.devel/641
+    if !gpg.empty? && !lines.index(GPG_END).nil?
       msg = RMail::Message.new
       msg.body = gpg.join("\n")
 


### PR DESCRIPTION
"lines.between() does not check if the end marker actually exists, but
later it is assumed the marker exists. This change introduces a check
for the end marker and doesn't decrypt messages in which the end marker
is missing. This is a fix for
http://rubyforge.org/pipermail/sup-talk/2010-August/004209.html"
