### PR TITLE
Load libc.so.7 instead of .6 on FreeBSD

### DIFF
--- a/bin/sup
+++ b/bin/sup
@@ -106,8 +106,6 @@ end
 ## ncurses.so that's been compiled against libncursesw. (note the w.) why
 ## this works, i have no idea. much like pretty much every aspect of
 ## dealing with curses.  cargo cult programming at its best.
-##
-## BSD users: if libc.so.6 is not found, try installing compat6x.
 require 'dl/import'
 require 'rbconfig'
 module LibC
@@ -115,6 +113,7 @@ module LibC
   setlocale_lib = case RbConfig::CONFIG['arch']
     when /darwin/; "libc.dylib"
     when /cygwin/; "cygwin1.dll"
+    when /freebsd/; "libc.so.7"
     else; "libc.so.6"
   end
 
@@ -127,9 +126,6 @@ module LibC
   rescue RuntimeError => e
     warn "cannot dlload setlocale(); ncurses wide character support probably broken."
     warn "dlload error was #{e.class}: #{e.message}"
-    if RbConfig::CONFIG['arch'] =~ /bsd/
-      warn "BSD variant detected. You may have to install a compat6x package to acquire libc."
-    end
   end
 end
 


### PR DESCRIPTION
Loading libc.so.6 results in a bazillion warnings like this:

> ruby19 in free(): warning: junk pointer, too high to make sense

Perhaps memory malloc()ed by libc.so.7 is attempted to be free()d via the libc.so.6 loaded afterwards.  In any case, everything seems to work fine with libc.so.7.
