### PR TITLE
Fixing gpgme support for gpgme 2.0

### DIFF
--- a/lib/sup/crypto.rb
+++ b/lib/sup/crypto.rb
@@ -64,9 +64,16 @@ EOS
     @gpgme_present =
       begin
         begin
-          GPGME.check_version({:protocol => GPGME::PROTOCOL_OpenPGP})
+          begin
+            GPGME.check_version({:protocol => GPGME::PROTOCOL_OpenPGP})
+          rescue TypeError
+            GPGME.check_version(nil)
+          end
           true
         rescue GPGME::Error
+          false
+        rescue ArgumentError
+          # gpgme 2.0.0 raises this due to the hash->string conversion
           false
         end
       rescue NameError
@@ -81,7 +88,11 @@ EOS
 
     # if gpg2 is available, it will start gpg-agent if required
     if (bin = `which gpg2`.chomp) =~ /\S/
-      GPGME.set_engine_info GPGME::PROTOCOL_OpenPGP, bin, nil
+      if GPGME.respond_to?('set_engine_info')
+        GPGME.set_engine_info GPGME::PROTOCOL_OpenPGP, bin, nil
+      else
+        GPGME.gpgme_set_engine_info GPGME::PROTOCOL_OpenPGP, bin, nil
+      end
     else
       # check if the gpg-options hook uses the passphrase_callback
       # if it doesn't then check if gpg agent is present
@@ -120,7 +131,13 @@ EOS
                                {:operation => "sign", :options => gpg_opts}) || gpg_opts
 
     begin
-      sig = GPGME.detach_sign(format_payload(payload), gpg_opts)
+      if GPGME.respond_to?('detach_sign')
+        sig = GPGME.detach_sign(format_payload(payload), gpg_opts)
+      else
+        crypto = GPGME::Crypto.new
+        gpg_opts[:mode] = GPGME::SIG_MODE_DETACH
+        sig = crypto.sign(format_payload(payload), gpg_opts).read
+      end
     rescue GPGME::Error => exc
       raise Error, gpgme_exc_msg(exc.message)
     end
@@ -153,7 +170,13 @@ EOS
     recipients = to + [from]
     recipients = HookManager.run("gpg-expand-keys", { :recipients => recipients }) || recipients
     begin
-      cipher = GPGME.encrypt(recipients, format_payload(payload), gpg_opts)
+      if GPGME.respond_to?('encrypt')
+        cipher = GPGME.encrypt(recipients, format_payload(payload), gpg_opts)
+      else
+        crypto = GPGME::Crypto.new
+        gpg_opts[:recipients] = recipients
+        cipher = crypto.encrypt(format_payload(payload), gpg_opts).read
+      end
     rescue GPGME::Error => exc
       raise Error, gpgme_exc_msg(exc.message)
     end
@@ -262,7 +285,11 @@ EOS
                                {:operation => "decrypt", :options => gpg_opts}) || gpg_opts
     ctx = GPGME::Ctx.new(gpg_opts)
     cipher_data = GPGME::Data.from_str(format_payload(payload))
-    plain_data = GPGME::Data.empty
+    if GPGME::Data.respond_to?('empty')
+      plain_data = GPGME::Data.empty
+    else
+      plain_data = GPGME::Data.empty!
+    end
     begin
       ctx.decrypt_verify(cipher_data, plain_data)
     rescue GPGME::Error => exc
@@ -330,7 +357,7 @@ private
 
   def gpgme_exc_msg msg
     err_msg = "Exception in GPGME call: #{msg}"
-    info err_msg
+    #info err_msg
     err_msg
   end
 

--- a/test/test_crypto.rb
+++ b/test/test_crypto.rb
@@ -1,0 +1,107 @@
+#!/usr/bin/ruby
+
+# tests for sup's crypto libs
+#
+# Copyright Clint Byrum <clint@ubuntu.com> 2011. All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+require 'tmpdir'
+require 'test/unit'
+require 'rmail/message'
+require 'rmail/parser'
+require 'sup/util'
+require 'sup/hook'
+require 'sup/contact'
+require 'sup/person'
+require 'sup/account'
+require 'sup/message-chunks'
+require 'sup/crypto'
+require 'stringio'
+
+module Redwood
+
+# These are all singletons
+CryptoManager.init
+Dir.mktmpdir('sup-test') do|f|
+    HookManager.init f
+end
+am = {:default=> {:name => "", :email=>ENV['EMAIL']}}
+AccountManager.init am
+
+class TestCryptoManager < Test::Unit::TestCase
+
+    def setup
+        @from_email = ENV['EMAIL']
+        # Change this or import my public key to make these tests work.
+        @to_email = 'clint@ubuntu.com'
+    end
+
+    def teardown
+    end
+
+    def test_sign
+        if CryptoManager.have_crypto? then
+            signed = CryptoManager.sign @from_email,@to_email,"ABCDEFG"
+            assert_instance_of RMail::Message, signed
+            assert_equal "ABCDEFG", signed.body[0]
+            assert signed.body[1].body.length > 0 , "signature length must be > 0"
+            assert (signed.body[1].body.include? "-----BEGIN PGP SIGNATURE-----") , "Expecting PGP armored data"
+        end
+    end
+
+    def test_encrypt
+        if CryptoManager.have_crypto? then
+            encrypted = CryptoManager.encrypt @from_email, [@to_email], "ABCDEFG"
+            assert_instance_of RMail::Message, encrypted
+            assert (encrypted.body[1].body.include? "-----BEGIN PGP MESSAGE-----") , "Expecting PGP armored data"
+        end
+    end
+
+    def test_sign_and_encrypt
+        if CryptoManager.have_crypto? then
+            encrypted = CryptoManager.sign_and_encrypt @from_email, [@to_email], "ABCDEFG"
+            assert_instance_of RMail::Message, encrypted
+            assert (encrypted.body[1].body.include? "-----BEGIN PGP MESSAGE-----") , "Expecting PGP armored data"
+        end
+    end
+
+    def test_decrypt
+        if CryptoManager.have_crypto? then
+            encrypted = CryptoManager.encrypt @from_email, [@to_email], "ABCDEFG"
+            assert_instance_of RMail::Message, encrypted
+            assert_instance_of String, (encrypted.body[1].body)
+            decrypted = CryptoManager.decrypt encrypted.body[1], true
+            assert_instance_of Array, decrypted
+            assert_instance_of Chunk::CryptoNotice, decrypted[0]
+            assert_instance_of Chunk::CryptoNotice, decrypted[1]
+            assert_instance_of RMail::Message, decrypted[2]
+            assert_equal "ABCDEFG" , decrypted[2].body
+        end
+    end
+
+    def test_verify
+        if CryptoManager.have_crypto?
+            signed = CryptoManager.sign @from_email, @to_email, "ABCDEFG"
+            assert_instance_of RMail::Message, signed
+            assert_instance_of String, (signed.body[1].body)
+            CryptoManager.verify signed.body[0], signed.body[1], true
+        end
+    end
+        
+end
+
+end


### PR DESCRIPTION
The API in gpgme 2.0 is vastly different than 1.0. This keeps backward compatibility but adds 2.0 support. Also adds a fairly complete test script for sup/crypto

(From https://gitorious.org/sup/mainline/merge_requests/12 - just found it and thought I should copy across to here. Note I haven't reviewed or tested the change, just putting it in the system for now).
