### PR TITLE
Missing require for sup/util/query

### DIFF
--- a/lib/sup/index.rb
+++ b/lib/sup/index.rb
@@ -6,6 +6,7 @@ require 'fileutils'
 require 'monitor'
 require 'chronic'
 
+require "sup/util/query"
 require "sup/interactive_lock"
 require "sup/hook"
 require "sup/logger/singleton"


### PR DESCRIPTION
Running the current develop branch, I get the error below when performing any kind of search. Adding this require seems to fix it. Is anyone else encountering this?

```
[2013-07-07 13:33:40 +0200] ERROR: oh crap, an exception
----------------------------------------------------------------
We are very sorry. It seems that an error occurred in Sup. Please
accept our sincere apologies. Please submit the contents of
/home/eric/.sup/exception-log.txt and a brief report of the
circumstances to https://github.com/sup-heliotrope/sup/issues so that 
we might address this problem. Thank you!

Sincerely,
The Sup Developers
----------------------------------------------------------------
--- NameError from thread: main
uninitialized constant Redwood::Index::Util
/home/eric/tmp/sup/lib/sup/index.rb:451:in `parse_query'
/home/eric/tmp/sup/lib/sup/util.rb:637:in `method_missing'
/home/eric/tmp/sup/lib/sup/modes/search_results_mode.rb:43:in `spawn_from_query'
/home/eric/tmp/sup/bin/sup:300:in `<module:Redwood>'
/home/eric/tmp/sup/bin/sup:74:in `<main>'
```
