### PR TITLE
Always Enable CJK n-gram Tokenization for Xapian

### DIFF
--- a/lib/sup/index.rb
+++ b/lib/sup/index.rb
@@ -1,4 +1,5 @@
 ENV["XAPIAN_FLUSH_THRESHOLD"] = "1000"
+ENV["XAPIAN_CJK_NGRAM"] = "1"
 
 require 'xapian'
 require 'set'


### PR DESCRIPTION
Fixes #60.

No performance regressions are noticed when indexing 2k mails. Will test on 20k mails later.
