### PR TITLE
Thread safer sigwinch handling and don't call stuff from trap context

### DIFF
--- a/lib/sup/buffer.rb
+++ b/lib/sup/buffer.rb
@@ -226,7 +226,8 @@ EOS
 
       @sigwinch_mutex.unlock
     rescue ThreadError
-      # thread locked by this thread already
+      # sigwinch_mutex locked by this thread already
+      debug "SIGWINCH already being handled in this thread."
     end
   end
 


### PR DESCRIPTION
Don't fail if mutex is already locked by current thread, but rather
return. The signwinch variable will be updated anyway.

Do the sigwinch stuff in a new thread as in the workaround in
https://bugs.ruby-lang.org/issues/7917#note-3

Should hopefully fix both: #59 and #90.
