### PR TITLE
Launch a new thread inside trap for sigwinch

### DIFF
--- a/bin/sup
+++ b/bin/sup
@@ -158,7 +158,11 @@ begin
 
   $die = false
   trap("TERM") { |x| $die = true }
-  trap("WINCH") { |x| BufferManager.sigwinch_happened! }
+  trap("WINCH") do |x|
+   ::Thread.new do
+     BufferManager.sigwinch_happened!
+   end
+  end
 
   if(s = Redwood::SourceManager.source_for DraftManager.source_name)
     DraftManager.source = s


### PR DESCRIPTION
As per https://bugs.ruby-lang.org/issues/7917#note-3.

Solves #59 and #90, and has the advantage over #109 to be consistent with the rest of the application. Also, redrawing is automatic :)
