### PR TITLE
Fix Gemfile rubygem source address.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'http://rubygems.org/'
+source 'https://rubygems.org/'
 
 gemspec


### PR DESCRIPTION
Rubygem source does no longer accepts connections via HTTP and we must use
HTTPS instead.
