### PR TITLE
Fail if alternate emails are not specified as array in config.yaml

### DIFF
--- a/lib/sup/account.rb
+++ b/lib/sup/account.rb
@@ -50,6 +50,7 @@ class AccountManager
       [:name, :sendmail, :signature, :gpgkey].each { |k| hash[k] ||= @default_account.send(k) }
     end
     hash[:alternates] ||= []
+    fail "alternative emails are not an array: #{hash[:alternates]}" unless hash[:alternates].kind_of? Array
 
     [:name, :signature].each { |x| hash[x] ? hash[x].fix_encoding : nil }
 


### PR DESCRIPTION
If alternate emails for an account is not specified as an array the account initializer will fail. This now fails with a more descriptive error message. To reproduce, change in config.yaml:

```
:alternates:
  - alt1@asdf.com
```

to

```
:alternates: alt1@asdf.com
```

still failing without any good reason:

```
:alternates: - alt1@asdf.com
```

^^^ probably invalid YAML.

in response to: http://rubyforge.org/pipermail/sup-talk/2013-August/004984.html
