### PR TITLE
Run write sent message in separate ::Thread

### DIFF
--- a/lib/sup/modes/edit_message_mode.rb
+++ b/lib/sup/modes/edit_message_mode.rb
@@ -484,10 +484,10 @@ protected
       m = build_message date
 
       if HookManager.enabled? "sendmail"
-    if not HookManager.run "sendmail", :message => m, :account => acct
-          warn "Sendmail hook was not successful"
-          return false
-    end
+        if not HookManager.run "sendmail", :message => m, :account => acct
+              warn "Sendmail hook was not successful"
+              return false
+        end
       else
         IO.popen(acct.sendmail, "w") { |p| p.puts m }
         raise SendmailCommandFailed, "Couldn't execute #{acct.sendmail}" unless $? == 0

--- a/lib/sup/sent.rb
+++ b/lib/sup/sent.rb
@@ -25,11 +25,13 @@ class SentManager
   end
 
   def write_sent_message date, from_email, &block
-    debug "store the sent message (locking sent source..)"
-    @source.poll_lock.synchronize do
-      @source.store_message date, from_email, &block
+    ::Thread.new do
+      debug "store the sent message (locking sent source..)"
+      @source.poll_lock.synchronize do
+        @source.store_message date, from_email, &block
+      end
+      PollManager.poll_from @source
     end
-    PollManager.poll_from @source
   end
 end
 


### PR DESCRIPTION
When sending message during a long poll on the same source as the message is sent to (at the moment only possible with the gmail source), the write message will be waiting for the poll to finish (because of the source poll lock) and the user must wait for it to finish. Better run the store message in a separate thread and which will write the message once the poll is finished.
