### PR TITLE
Avoid crash when (maybe) wrapping text

### DIFF
--- a/lib/sup/modes/thread_view_mode.rb
+++ b/lib/sup/modes/thread_view_mode.rb
@@ -846,6 +846,10 @@ private
       else
         width = buffer.content_width
       end
+      # lines can apparently be both String and Array, convert to Array for map.
+      if lines.kind_of? String
+        lines = lines.lines.to_a
+      end
       lines = lines.map { |l| l.chomp.wrap width if l }.flatten
     end
     return lines


### PR DESCRIPTION
The function maybe_wrap_text apparently receives input as both String and Array.

This piece of code converts String input to Array.

Related patch

http://patch-tracker.debian.org/patch/series/view/sup-mail/0.12.1+git20120407.aaa852f-1/0004-Avoid-crash-when-maybe-wrapping-text.patch
