### PR TITLE
Remove crash when sup is unconfigured

### DIFF
--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -370,11 +370,11 @@ class String
     # first try to set the string to utf-8 and check if it is valid
     # in case ruby just thinks it is something else
     orig_encoding = encoding
-    force_encoding 'UTF-8'
+    encode 'UTF-8'
     return self if valid_encoding?
 
     # that didn't work, go back to original and try to convert
-    force_encoding orig_encoding
+    encode orig_encoding
 
     encode!('UTF-8', :invalid => :replace, :undef => :replace)
 


### PR DESCRIPTION
This replaces #force_encoding with #encode.

This resolves that sup crashes upon start when no `$HOME/.sup` directory exists.

Motivation and related reading: http://yugui.jp/articles/850
