### PR TITLE
Force encode ncurses input to $encoding

### DIFF
--- a/lib/sup/buffer.rb
+++ b/lib/sup/buffer.rb
@@ -622,7 +622,7 @@ EOS
       tf.deactivate
       draw_screen :sync => false, :status => status, :title => title
     end
-    tf.value.tap { |x| x.fix_encoding if x }
+    tf.value.tap { |x| x }
   end
 
   def ask_getch question, accept=nil

--- a/lib/sup/textfield.rb
+++ b/lib/sup/textfield.rb
@@ -168,6 +168,16 @@ private
     else # trailing spaces
       v + (" " * (x - @question.length - v.length))
     end
+
+    # ncurses returns a ASCII-8BIT (binary) string, which
+    # bytes presumably are of current charset encoding. we force_encoding
+    # so that the char representation / string is tagged will be the
+    # system locale and also hopefully the terminal/input encoding. an
+    # incorrectly configured terminal encoding (not matching the system
+    # encoding) will produce erronous results, but will also do that for
+    # a log of other programs since it is impossible to detect which is
+    # which and what encoding the inputted byte chars are supposed to have.
+    v.force_encoding($encoding).fix_encoding
   end
 
   def remove_extra_space

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -367,15 +367,7 @@ class String
   #
   # Not Ruby 1.8 compatible
   def fix_encoding
-    # first try to set the string to utf-8 and check if it is valid
-    # in case ruby just thinks it is something else
-    orig_encoding = encoding
-    force_encoding 'UTF-8'
-    return self if valid_encoding?
-
-    # that didn't work, go back to original and try to convert
-    force_encoding orig_encoding
-
+    # first try to encode to utf-8 from whatever current encoding
     encode!('UTF-8', :invalid => :replace, :undef => :replace)
 
     # do this anyway in case string is set to be UTF-8, encoding to


### PR DESCRIPTION
Avoids using force_encoding incorrectly in fix_encoding. Assumes ncurses input to be in $encoding since it is tagged as ASCII-8BIT (binary).

Alternative to #124 and should replace some of the changes in #120. Should not re-introduce #117 and #115.
