### PR TITLE
Fix fix_encoding on frozen string

### DIFF
--- a/bin/sup
+++ b/bin/sup
@@ -293,7 +293,7 @@ begin
       b.mode.load_in_background if new
     when :search
       completions = LabelManager.all_labels.map { |l| "label:#{LabelManager.string_for l}" }
-      completions = completions.each { |l| l.fix_encoding }
+      completions = completions.each { |l| l.fix_encoding! }
       completions += Index::COMPL_PREFIXES
       query = BufferManager.ask_many_with_completions :search, "Search all messages (enter for saved searches): ", completions
       unless query.nil?
@@ -307,7 +307,7 @@ begin
       SearchResultsMode.spawn_from_query "is:unread"
     when :list_labels
       labels = LabelManager.all_labels.map { |l| LabelManager.string_for l }
-      labels = labels.each { |l| l.fix_encoding }
+      labels = labels.each { |l| l.fix_encoding! }
 
       user_label = bm.ask_with_completions :label, "Show threads with label (enter for listing): ", labels
       unless user_label.nil?

--- a/lib/sup.rb
+++ b/lib/sup.rb
@@ -271,7 +271,7 @@ EOM
     else
       require 'etc'
       require 'socket'
-      name = Etc.getpwnam(ENV["USER"]).gecos.split(/,/).first.force_encoding($encoding).fix_encoding rescue nil
+      name = Etc.getpwnam(ENV["USER"]).gecos.split(/,/).first.force_encoding($encoding).fix_encoding! rescue nil
       name ||= ENV["USER"]
       email = ENV["USER"] + "@" +
         begin
@@ -283,8 +283,8 @@ EOM
       config = {
         :accounts => {
           :default => {
-            :name => name.fix_encoding,
-            :email => email.fix_encoding,
+            :name => name.dup.fix_encoding!,
+            :email => email.fix_encoding!,
             :alternates => [],
             :sendmail => "/usr/sbin/sendmail -oem -ti",
             :signature => File.join(ENV["HOME"], ".signature"),

--- a/lib/sup/account.rb
+++ b/lib/sup/account.rb
@@ -52,7 +52,7 @@ class AccountManager
     hash[:alternates] ||= []
     fail "alternative emails are not an array: #{hash[:alternates]}" unless hash[:alternates].kind_of? Array
 
-    [:name, :signature].each { |x| hash[x] ? hash[x].fix_encoding : nil }
+    [:name, :signature].each { |x| hash[x] ? hash[x].fix_encoding! : nil }
 
     a = Account.new hash
     @accounts[a] = true

--- a/lib/sup/buffer.rb
+++ b/lib/sup/buffer.rb
@@ -449,7 +449,7 @@ EOS
 
   def ask_with_completions domain, question, completions, default=nil
     ask domain, question, default do |s|
-      s.fix_encoding
+      s.fix_encoding!
       completions.select { |x| x =~ /^#{Regexp::escape s}/iu }.map { |x| [x, x] }
     end
   end
@@ -466,8 +466,8 @@ EOS
           raise "william screwed up completion: #{partial.inspect}"
         end
 
-      prefix.fix_encoding
-      target.fix_encoding
+      prefix.fix_encoding!
+      target.fix_encoding!
       completions.select { |x| x =~ /^#{Regexp::escape target}/iu }.map { |x| [prefix + x, x] }
     end
   end
@@ -476,10 +476,10 @@ EOS
     ask domain, question, default do |partial|
       prefix, target = partial.split_on_commas_with_remainder
       target ||= prefix.pop || ""
-      target.fix_encoding
+      target.fix_encoding!
 
       prefix = prefix.join(", ") + (prefix.empty? ? "" : ", ")
-      prefix.fix_encoding
+      prefix.fix_encoding!
 
       completions.select { |x| x =~ /^#{Regexp::escape target}/iu }.sort_by { |c| [ContactManager.contact_for(c) ? 0 : 1, c] }.map { |x| [prefix + x, x] }
     end

--- a/lib/sup/crypto.rb
+++ b/lib/sup/crypto.rb
@@ -340,7 +340,7 @@ EOS
       msg = RMail::Parser.read output
       if msg.header.content_type =~ %r{^multipart/} && !msg.multipart?
         output = "MIME-Version: 1.0\n" + output
-        output.fix_encoding
+        output.fix_encoding!
         msg = RMail::Parser.read output
       end
     end

--- a/lib/sup/message.rb
+++ b/lib/sup/message.rb
@@ -112,7 +112,7 @@ class Message
     end
 
     subj = header["subject"]
-    subj = subj ? subj.fix_encoding : nil
+    subj = subj ? subj.fix_encoding! : nil
     @subj = subj ? subj.gsub(/\s+/, " ").gsub(/\s+$/, "") : DEFAULT_SUBJECT
     @to = Person.from_address_list header["to"]
     @cc = Person.from_address_list header["cc"]

--- a/lib/sup/textfield.rb
+++ b/lib/sup/textfield.rb
@@ -177,7 +177,7 @@ private
     # encoding) will produce erronous results, but will also do that for
     # a log of other programs since it is impossible to detect which is
     # which and what encoding the inputted byte chars are supposed to have.
-    v.force_encoding($encoding).fix_encoding
+    v.force_encoding($encoding).fix_encoding!
   end
 
   def remove_extra_space

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -125,7 +125,7 @@ module RMail
       class << self
         def parse(field)
           field = field.dup.to_s
-          field = field.fix_encoding.ascii
+          field = field.fix_encoding!.ascii
           if field =~ EXTRACT_FIELD_NAME_RE
             [ $1, $'.chomp ]
           else
@@ -366,7 +366,7 @@ class String
   # user encoding.
   #
   # Not Ruby 1.8 compatible
-  def fix_encoding
+  def fix_encoding!
     # first try to encode to utf-8 from whatever current encoding
     encode!('UTF-8', :invalid => :replace, :undef => :replace)
 
@@ -402,7 +402,7 @@ class String
 
     rescue Encoding::ConverterNotFoundError
       debug "Encoding converter not found for #{from_encoding.inspect} or #{to_encoding.inspect}, fixing string: '#{self.to_s}', but expect weird characters."
-      fix_encoding
+      fix_encoding!
     end
 
     fail "Could not create valid #{to_encoding.inspect} string out of: '#{self.to_s}'." unless valid_encoding?
@@ -411,7 +411,7 @@ class String
   end
 
   def normalize_whitespace
-    fix_encoding
+    fix_encoding!
     gsub(/\t/, "    ").gsub(/\r/, "")
   end
 
@@ -453,7 +453,7 @@ class String
         out << b.chr
       end
     end
-    out = out.fix_encoding # this should now be an utf-8 string of ascii
+    out = out.fix_encoding! # this should now be an utf-8 string of ascii
                            # compat chars.
   end
 


### PR DESCRIPTION
This PR solves 2 problems:
- Replace fix_encoding with fix_encoding! to mark the fact that it is a potentially destructive operation
- Use fix_encoding on a dup of a frozen string if needed
