### PR TITLE
Fix encoding on message to be forwarded

### DIFF
--- a/lib/sup/modes/edit_message_mode.rb
+++ b/lib/sup/modes/edit_message_mode.rb
@@ -489,7 +489,7 @@ protected
               return false
         end
       else
-        IO.popen(acct.sendmail, "w") { |p| p.puts m }
+        IO.popen(acct.sendmail, "w:UTF-8") { |p| p.puts m }
         raise SendmailCommandFailed, "Couldn't execute #{acct.sendmail}" unless $? == 0
       end
 
@@ -517,7 +517,7 @@ protected
     m.body += "\n" + sig_lines.join("\n") unless @sig_edited
     ## body must end in a newline or GPG signatures will be WRONG!
     m.body += "\n" unless m.body =~ /\n\Z/
-    m.body = m.body.fix_encoding
+    m.body = m.body.fix_encoding!
 
     ## there are attachments, so wrap body in an attachment of its own
     unless @attachments.empty?
@@ -526,7 +526,10 @@ protected
       m = RMail::Message.new
 
       m.add_part body_m
-      @attachments.each { |a| m.add_part a }
+      @attachments.each do |a|
+        a.body = a.body.fix_encoding! if a.body.kind_of? String
+        m.add_part a
+      end
     end
 
     ## do whatever crypto transformation is necessary
@@ -548,9 +551,9 @@ protected
       m.header[k] =
         case v
         when String
-          k.match(/subject/i) ? mime_encode_subject(v) : mime_encode_address(v)
+          (k.match(/subject/i) ? mime_encode_subject(v) : mime_encode_address(v)).fix_encoding!
         when Array
-          v.map { |v| mime_encode_address v }.join ", "
+          (v.map { |v| mime_encode_address v }.join ", ").fix_encoding!
         end
     end
 


### PR DESCRIPTION
Attempt to fix #135: Forwarded message may contain invalid encoding.
