### PR TITLE
Predefine 'all mail' search

### DIFF
--- a/lib/sup/modes/search_list_mode.rb
+++ b/lib/sup/modes/search_list_mode.rb
@@ -86,7 +86,11 @@ protected
     counted = searches.map do |name|
       search_string = SearchManager.search_string_for name
       begin
-        query = Index.parse_query search_string
+        if SearchManager.predefined_queries.has_key? search_string
+          query = SearchManager.predefined_queries[search_string]
+        else
+          query = Index.parse_query search_string
+        end
         total = Index.num_results_for :qobj => query[:qobj]
         unread = Index.num_results_for :qobj => query[:qobj], :label => :unread
       rescue Index::ParseError => e

--- a/lib/sup/modes/search_results_mode.rb
+++ b/lib/sup/modes/search_results_mode.rb
@@ -40,7 +40,11 @@ class SearchResultsMode < ThreadIndexMode
 
   def self.spawn_from_query text
     begin
-      query = Index.parse_query(text)
+      if SearchManager.predefined_queries.has_key? text
+        query = SearchManager.predefined_queries[text]
+      else
+        query = Index.parse_query(text)
+      end
       return unless query
       short_text = text.length < 20 ? text : text[0 ... 20] + "..."
       mode = SearchResultsMode.new query

--- a/lib/sup/search.rb
+++ b/lib/sup/search.rb
@@ -15,10 +15,27 @@ class SearchManager
       end
     end
     @modified = false
+
+    @predefined_searches = { 'All mail' => 'Search all mail.' }
+    @predefined_queries  = { 'All mail'.to_sym => { :qobj => Xapian::Query.new('Kmail'),
+                                                    :load_spam => false,
+                                                    :load_deleted => false,
+                                                    :load_killed => false,
+                                                    :text => 'Search all mail.'}
+    }
+    @predefined_searches.each do |k,v|
+      @searches[k] = v
+    end
   end
 
+  def predefined_queries; return @predefined_queries; end
   def all_searches; return @searches.keys.sort; end
-  def search_string_for name; return @searches[name]; end
+  def search_string_for name;
+    if @predefined_searches.keys.member? name
+      return name.to_sym
+    end
+    return @searches[name];
+  end
   def valid_name? name; name =~ /^[\w-]+$/; end
   def name_format_hint; "letters, numbers, underscores and dashes only"; end
 
@@ -65,7 +82,7 @@ class SearchManager
 
   def save
     return unless @modified
-    File.open(@fn, "w") { |f| @searches.sort.each { |(n, s)| f.puts "#{n}: #{s}" } }
+    File.open(@fn, "w") { |f| (@searches - @predefined_searches.keys).sort.each { |(n, s)| f.puts "#{n}: #{s}" } }
     @modified = false
   end
 end


### PR DESCRIPTION
Alternative fix to #53. A predefined 'All Mail' search which lists all mail.
