### PR TITLE
Maildir-syncback: Synchronize with poll_lock (possibly in a non-blocking way/or a separate thread) in all operations that write a new message or changes a message

### DIFF
--- a/lib/sup/maildir.rb
+++ b/lib/sup/maildir.rb
@@ -77,8 +77,11 @@ class Maildir < Source
   end
 
   def sync_back id, labels
-    flags = maildir_reconcile_flags id, labels
-    maildir_mark_file id, flags
+    synchronize do
+      debug "syncing back maildir message #{id} with flags #{labels.to_a}"
+      flags = maildir_reconcile_flags id, labels
+      maildir_mark_file id, flags
+    end
   end
 
   def raw_header id

--- a/lib/sup/poll.rb
+++ b/lib/sup/poll.rb
@@ -195,9 +195,8 @@ EOS
   ## labels and locations set correctly. The Messages are saved to or removed
   ## from the index after being yielded.
   def poll_from source, opts={}
-    debug "trying to acquire poll lock for: #{source}.."
-    if source.poll_lock.try_lock
-      debug "lock acquired for: #{source}."
+    debug "trying to acquire poll lock for: #{source}..."
+    if source.try_lock
       begin
         source.poll do |sym, args|
           case sym
@@ -258,7 +257,7 @@ EOS
 
       ensure
         source.go_idle
-        source.poll_lock.unlock
+        source.unlock
       end
     else
       debug "source #{source} is already being polled."

--- a/lib/sup/sent.rb
+++ b/lib/sup/sent.rb
@@ -27,7 +27,7 @@ class SentManager
   def write_sent_message date, from_email, &block
     ::Thread.new do
       debug "store the sent message (locking sent source..)"
-      @source.poll_lock.synchronize do
+      @source.synchronize do
         @source.store_message date, from_email, &block
       end
       PollManager.poll_from @source


### PR DESCRIPTION
Some of the operations in maildir-syncback are not locking on @poll_lock, risking a running poll operation while or during an operation that writes a message.

@ericweikl: Putting you as responsible since you're our maildir-syncback guy.
