### PR TITLE
maildir-syncback: forward message (with only attachment) fails

### DIFF
--- a/lib/sup/modes/forward_mode.rb
+++ b/lib/sup/modes/forward_mode.rb
@@ -72,8 +72,10 @@ protected
 
   def send_message
     return unless super # super returns true if the mail has been sent
-    @m.add_label :forwarded
-    Index.save_message @m
+    if @m
+      @m.add_label :forwarded
+      Index.save_message @m
+    end
   end
 end
 


### PR DESCRIPTION
The maidir-syncback branch adds a `send_message` to forward mode which does not account for when only an attachment has been marked and forwarded. In which case there is no `@m` available to add the :forwarded label to.

Possible solution, just skip the label adding if no `@m` since its not the original message that has been forwarded anyway...

```
--- NoMethodError from thread: main
undefined method `add_label' for nil:NilClass
/home/gaute/.rvm/gems/ruby-1.9.3-p392/gems/sup-999/lib/sup/modes/forward_mode.rb:75:in `send_message'
/home/gaute/.rvm/gems/ruby-1.9.3-p392/gems/sup-999/lib/sup/mode.rb:59:in `handle_input'
/home/gaute/.rvm/gems/ruby-1.9.3-p392/gems/sup-999/lib/sup/buffer.rb:273:in `handle_input'
/home/gaute/.rvm/gems/ruby-1.9.3-p392/gems/sup-999/bin/sup:265:in `<module:Redwood>'
/home/gaute/.rvm/gems/ruby-1.9.3-p392/gems/sup-999/bin/sup:73:in `<top (required)>'
/home/gaute/.rvm/gems/ruby-1.9.3-p392/bin/sup:19:in `load'
/home/gaute/.rvm/gems/ruby-1.9.3-p392/bin/sup:19:in `<main>'
/home/gaute/.rvm/gems/ruby-1.9.3-p392/bin/ruby_noexec_wrapper:14:in `eval'
/home/gaute/.rvm/gems/ruby-1.9.3-p392/bin/ruby_noexec_wrapper:14:in `<main>'
```
