### PR TITLE
Invalid byte sequence in UTF-8 

### DIFF
--- a/lib/sup/modes/edit_message_mode.rb
+++ b/lib/sup/modes/edit_message_mode.rb
@@ -640,7 +640,7 @@ private
   end
 
   def top_posting?
-    @body.join("\n").fix_encoding! =~ /(\S+)\s*Excerpts from.*\n(>.*\n)+\s*\Z/
+    @body.map { |x| x.fix_encoding! }.join("\n").fix_encoding! =~ /(\S+)\s*Excerpts from.*\n(>.*\n)+\s*\Z/
   end
 
   def sig_lines


### PR DESCRIPTION
Sup crashes when I try to respond to a message with some unrecognized characters earlier in the comment thread (which is unfortunately extremely common). I hexdumped the message and here are the two lines I think sup is tripping on. Getting rid of that part of the quoted message allows my reply to go through.

```
000002a0  3b 73 20 74 68 65 20 50  44 46 2e c2 a0 3c 64 69  |;s the PDF...<di|
000002f0  6f 75 3f c2 a0 3c 2f 64  69 76 3e 0a 0a 0a 0a 3c  |ou?..</div>....<|
```

Here's the stack trace from ~/.sup/exception-log.txt:

```
--- ArgumentError from thread: main
invalid byte sequence in UTF-8
/home/pinaki/.gem/ruby/1.9.1/gems/sup-0.14.1/lib/sup/modes/edit_message_mode.rb:643:in `top_posting?'
/home/pinaki/.gem/ruby/1.9.1/gems/sup-0.14.1/lib/sup/modes/edit_message_mode.rb:470:in `send_message'
/home/pinaki/.gem/ruby/1.9.1/gems/sup-0.14.1/lib/sup/mode.rb:59:in `handle_input'
/home/pinaki/.gem/ruby/1.9.1/gems/sup-0.14.1/lib/sup/buffer.rb:273:in `handle_input'
/home/pinaki/.gem/ruby/1.9.1/gems/sup-0.14.1/bin/sup:265:in `<module:Redwood>'
/home/pinaki/.gem/ruby/1.9.1/gems/sup-0.14.1/bin/sup:73:in `<top (required)>'
/home/pinaki/.gem/ruby/1.9.1/bin/sup:23:in `load'
/home/pinaki/.gem/ruby/1.9.1/bin/sup:23:in `<main>'
```

I get a slightly different stack trace if I try to send it with an attachment.

```
--- ArgumentError from thread: main
invalid byte sequence in UTF-8
/home/pinaki/.gem/ruby/1.9.1/gems/sup-0.14.1/lib/sup/modes/edit_message_mode.rb:638:in `block in mentions_attachments?'
/home/pinaki/.gem/ruby/1.9.1/gems/sup-0.14.1/lib/sup/modes/edit_message_mode.rb:638:in `each'
/home/pinaki/.gem/ruby/1.9.1/gems/sup-0.14.1/lib/sup/modes/edit_message_mode.rb:638:in `any?'
/home/pinaki/.gem/ruby/1.9.1/gems/sup-0.14.1/lib/sup/modes/edit_message_mode.rb:638:in `mentions_attachments?'
/home/pinaki/.gem/ruby/1.9.1/gems/sup-0.14.1/lib/sup/modes/edit_message_mode.rb:469:in `send_message'
/home/pinaki/.gem/ruby/1.9.1/gems/sup-0.14.1/lib/sup/mode.rb:59:in `handle_input'
/home/pinaki/.gem/ruby/1.9.1/gems/sup-0.14.1/lib/sup/buffer.rb:273:in `handle_input'
/home/pinaki/.gem/ruby/1.9.1/gems/sup-0.14.1/bin/sup:265:in `<module:Redwood>'
/home/pinaki/.gem/ruby/1.9.1/gems/sup-0.14.1/bin/sup:73:in `<top (required)>'
/home/pinaki/.gem/ruby/1.9.1/bin/sup:23:in `load'
/home/pinaki/.gem/ruby/1.9.1/bin/sup:23:in `<main>'
```
