### PR TITLE
Process persistent tempfiles

### DIFF
--- a/lib/sup/message_chunks.rb
+++ b/lib/sup/message_chunks.rb
@@ -1,5 +1,6 @@
 require 'tempfile'
 require 'rbconfig'
+require 'shellwords'
 
 ## Here we define all the "chunks" that a message is parsed
 ## into. Chunks are used by ThreadViewMode to render a message. Chunks
@@ -176,7 +177,7 @@ EOS
 
     def write_to_disk
       begin
-        file = Tempfile.new(["sup", @filename.gsub("/", "_") || "sup-attachment"])
+        file = Tempfile.new(["sup", Shellwords.escape(@filename.gsub("/", "_")) || "sup-attachment"])
         file.print @raw_content
         yield file if block_given?
         return file.path


### PR DESCRIPTION
With a mailcap set up to spawn a non-blocking viewing command I experience that the tempfiles are gone before the viewer gets to open it. This patch simply stores the tempfiles in a class variable so that they are not garbage collected before the entire process is ended.
