### PR TITLE
crash: incompatible character encodings: UTF-8 and ASCII-8BIT

### DIFF
--- a/lib/sup/modes/thread_view_mode.rb
+++ b/lib/sup/modes/thread_view_mode.rb
@@ -786,7 +786,7 @@ private
       @person_lines[start] = m.from
       [[prefix_widget, open_widget, new_widget, attach_widget, starred_widget,
         [color,
-        "#{m.from ? m.from.mediumname : '?'}, #{m.date.to_nice_s} (#{m.date.to_nice_distance_s})  #{m.snippet}"]]]
+        "#{m.from ? m.from.mediumname.fix_encoding! : '?'}, #{m.date.to_nice_s.fix_encoding!} (#{m.date.to_nice_distance_s.fix_encoding!})  #{m.snippet.fix_encoding!}"]]]
 
     when :detailed
       @person_lines[start] = m.from


### PR DESCRIPTION
Crash when opening mail. My version is 0.13-2, any newer does not run yet because of unmet dependencies, so I'm not sure if newer versions also show this issue.

```
[2013-09-24 15:28:04 +0200] ERROR: oh crap, an exception
----------------------------------------------------------------
We are very sorry. It seems that an error occurred in Sup. Please
accept our sincere apologies. Please submit the contents of
/home/ico/.sup/exception-log.txt and a brief report of the
circumstances to https://github.com/sup-heliotrope/sup/issues so that
we might address this problem. Thank you!

Sincerely,
The Sup Developers
----------------------------------------------------------------
--- Encoding::CompatibilityError from thread: load messages for thread-view-mode
incompatible character encodings: UTF-8 and ASCII-8BIT
/home/ico/external/sup/lib/sup/modes/thread_view_mode.rb:789:in `message_patina_lines'
/home/ico/external/sup/lib/sup/modes/thread_view_mode.rb:863:in `chunk_to_lines'
/home/ico/external/sup/lib/sup/modes/thread_view_mode.rb:721:in `block in regen_text'
/home/ico/external/sup/lib/sup/thread.rb:68:in `block in each'
/home/ico/external/sup/lib/sup/thread.rb:176:in `block (2 levels) in each_with_stuff'
/home/ico/external/sup/lib/sup/thread.rb:176:in `block (2 levels) in each_with_stuff'
/home/ico/external/sup/lib/sup/thread.rb:176:in `block (2 levels) in each_with_stuff'
/home/ico/external/sup/lib/sup/thread.rb:176:in `block (2 levels) in each_with_stuff'
/home/ico/external/sup/lib/sup/thread.rb:176:in `block (2 levels) in each_with_stuff'
/home/ico/external/sup/lib/sup/thread.rb:174:in `each_with_stuff'
/home/ico/external/sup/lib/sup/thread.rb:176:in `block in each_with_stuff'
/home/ico/external/sup/lib/sup/thread.rb:175:in `each'
/home/ico/external/sup/lib/sup/thread.rb:175:in `each_with_stuff'
/home/ico/external/sup/lib/sup/thread.rb:176:in `block in each_with_stuff'
/home/ico/external/sup/lib/sup/thread.rb:175:in `each'
/home/ico/external/sup/lib/sup/thread.rb:175:in `each_with_stuff'
/home/ico/external/sup/lib/sup/thread.rb:176:in `block in each_with_stuff'
/home/ico/external/sup/lib/sup/thread.rb:175:in `each'
/home/ico/external/sup/lib/sup/thread.rb:175:in `each_with_stuff'
/home/ico/external/sup/lib/sup/thread.rb:176:in `block in each_with_stuff'
/home/ico/external/sup/lib/sup/thread.rb:175:in `each'
/home/ico/external/sup/lib/sup/thread.rb:175:in `each_with_stuff'
/home/ico/external/sup/lib/sup/thread.rb:176:in `block in each_with_stuff'
/home/ico/external/sup/lib/sup/thread.rb:175:in `each'
/home/ico/external/sup/lib/sup/thread.rb:175:in `each_with_stuff'
/home/ico/external/sup/lib/sup/thread.rb:67:in `each'
/home/ico/external/sup/lib/sup/modes/thread_view_mode.rb:710:in `regen_text'
/home/ico/external/sup/lib/sup/modes/thread_view_mode.rb:172:in `buffer='
/home/ico/external/sup/lib/sup/buffer.rb:384:in `spawn'
(eval):1:in `spawn'
/home/ico/external/sup/lib/sup/modes/thread_index_mode.rb:120:in `block in select'
/home/ico/external/sup/lib/sup.rb:82:in `block in reporting_thread'

```
