### PR TITLE
Encoding::CompatibilityError from thread .... incompatible encoding regexp match

### DIFF
--- a/lib/sup/message_chunks.rb
+++ b/lib/sup/message_chunks.rb
@@ -129,6 +129,7 @@ EOS
           @lines = text.gsub("\r\n", "\n").gsub(/\t/, "        ").gsub(/\r/, "").split("\n")
         rescue Encoding::CompatibilityError
           @lines = text.fix_encoding!.gsub("\r\n", "\n").gsub(/\t/, "        ").gsub(/\r/, "").split("\n")
+          debug "error while decoding message text, falling back to default encoding, expect errors in encoding: #{text.fix_encoding!}"
         end
 
         @quotable = true


### PR DESCRIPTION
A bit after starting sup crashes with this error

```
--- Encoding::CompatibilityError from thread: poll after loading inbox
incompatible encoding regexp match (US-ASCII regexp with UTF-16LE string)
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/message_chunks.rb:128:in `gsub'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/message_chunks.rb:128:in `initialize'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/message.rb:516:in `new'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/message.rb:516:in `message_to_chunks'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/message.rb:434:in `block in message_to_chunks'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/message.rb:434:in `map'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/message.rb:434:in `message_to_chunks'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/message.rb:263:in `load_from_source!'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/message.rb:334:in `build_from_source'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/poll.rb:181:in `block in poll_from'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/maildir.rb:106:in `block (2 levels) in poll'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/maildir.rb:105:in `each'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/maildir.rb:105:in `each_with_index'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/maildir.rb:105:in `block in poll'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/maildir.rb:90:in `each'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/maildir.rb:90:in `poll'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/poll.rb:178:in `poll_from'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/poll.rb:134:in `block (2 levels) in do_poll'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/poll.rb:124:in `each'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/poll.rb:124:in `block in do_poll'
<internal:prelude>:10:in `synchronize'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/poll.rb:123:in `do_poll'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/util.rb:639:in `method_missing'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/modes/poll_mode.rb:15:in `poll'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/poll.rb:55:in `poll_with_sources'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/poll.rb:82:in `poll'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup/util.rb:639:in `method_missing'
/var/lib/gems/1.9.1/gems/sup-0.14.1/bin/sup:217:in `block (2 levels) in <module:Redwood>'
/var/lib/gems/1.9.1/gems/sup-0.14.1/lib/sup.rb:85:in `block in reporting_thread'
```
