### PR TITLE
Email attachment deletion fail

### DIFF
--- a/lib/sup/modes/edit_message_mode.rb
+++ b/lib/sup/modes/edit_message_mode.rb
@@ -319,7 +319,7 @@ EOS
   end
 
   def delete_attachment
-    i = curpos - @attachment_lines_offset - DECORATION_LINES - 2
+    i = curpos - @attachment_lines_offset - (@selectors.empty? ? 0 : DECORATION_LINES) - @selectors.size
     if i >= 0 && i < @attachments.size && BufferManager.ask_yes_or_no("Delete attachment #{@attachment_names[i]}?")
       @attachments.delete_at i
       @attachment_names.delete_at i


### PR DESCRIPTION
When editing an email response or a new email, trying to delete an attachment doesn't delete the highlighted attachment, but delete the previous one, or none if only one attachment is left.

After a quick investigation, this is probably due to an error in the calculation of the attachment index from the cursor position, in edit_message_mode.rb:323, in method delete_attachment.
