### PR TITLE
More contrast in highlighted/selected message

### DIFF
--- a/lib/sup/colormap.rb
+++ b/lib/sup/colormap.rb
@@ -111,8 +111,10 @@ class Colormap
       case fg
       when Curses::COLOR_BLUE
         Curses::COLOR_WHITE
-      when Curses::COLOR_YELLOW, Curses::COLOR_GREEN
+      when Curses::COLOR_YELLOW, Curses::COLOR_GREEN, Curses::COLOR_CYAN
         fg
+      when Curses::COLOR_WHITE
+        Curses::COLOR_WHITE
       else
         Curses::COLOR_BLACK
       end


### PR DESCRIPTION
Attached is a suggestion for some slight changes in calculating colors for the highlighted message. It could be made configurable as well, but currently the implementation doesn't allow that. Is this a bad idea? How does it work with your terminal color schemes?

![2013-09-30-114750_1364x634_scrot](https://f.cloud.github.com/assets/56827/1236065/ad343f4c-29b6-11e3-964a-a480476ee174.png)
