### PR TITLE
Maildir sync crashes when .sup/sync-back-ok does not exist

### DIFF
--- a/bin/sup-sync-back-maildir
+++ b/bin/sup-sync-back-maildir
@@ -1,4 +1,7 @@
 #!/usr/bin/env ruby
+# encoding: utf-8
+
+$:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
 require 'rubygems'
 require 'trollop'

--- a/lib/sup.rb
+++ b/lib/sup.rb
@@ -189,9 +189,9 @@ EOS
 Should I complain about this again? (Y/n)
 EOS
         File.open(Redwood::SYNC_OK_FN, 'w') {|f| f.write(Redwood::MAILDIR_SYNC_CHECK_SKIPPED) } if STDIN.gets.chomp.downcase == 'n'
-      elsif not $config[:sync_back_to_maildir] and File.exists? Redwood::SYNC_OK_FN
-        File.delete(Redwood::SYNC_OK_FN)
       end
+    elsif not $config[:sync_back_to_maildir] and File.exists? Redwood::SYNC_OK_FN
+      File.delete(Redwood::SYNC_OK_FN)
     end
   end
 
@@ -203,13 +203,18 @@ EOS
     sources = SourceManager.sources
     newly_synced = sources.select { |s| s.is_a? Maildir and s.sync_back_enabled? and not active_sync_sources.include? s.uri }
     unless newly_synced.empty?
-      Redwood.warn_syncback <<EOS
+
+      details =<<EOS
 It appears that the option "sync_back" of the following source(s)
 has been changed from false to true since the last execution of
 sup:
 
-#{newly_synced.join("\n")}
 EOS
+      newly_synced.each do |s|
+        details += "#{s} (usual: #{s.usual})\n"
+      end
+
+      Redwood.warn_syncback details
     end
   end
 
@@ -223,6 +228,9 @@ WARNING
 It is *strongly* recommended that you run "sup-sync-back-maildir"
 before continuing, otherwise you might lose informations in your
 Xapian index.
+
+Please note that if you have any sources that are not marked as 'ususal'
+you need to manually specify them to the sup-sync-back-maildir script.
 
 This script should be executed each time the "sync_back_to_maildir" is
 changed from false to true.

--- a/lib/sup/source.rb
+++ b/lib/sup/source.rb
@@ -54,7 +54,7 @@ class Source
   ## Examples for you to look at: mbox.rb and maildir.rb.
 
   bool_accessor :usual, :archived
-  attr_reader :uri
+  attr_reader :uri, :usual
   attr_accessor :id
 
   def initialize uri, usual=true, archived=false, id=nil


### PR DESCRIPTION
Just moved to upstream/develop 43e4c1ed17e085501112c8a8b406060c5c775eb3: 

```
/home/ico/external/sup/lib/sup/util.rb:123: warning: already initialized constant EXTRACT_FIELD_NAME_RE
[2013-10-10 09:51:13 +0200] ERROR: oh crap, an exception
----------------------------------------------------------------
We are very sorry. It seems that an error occurred in Sup. Please
accept our sincere apologies. Please submit the contents of
/home/ico/.sup/exception-log.txt and a brief report of the
circumstances to https://github.com/sup-heliotrope/sup/issues so that
we might address this problem. Thank you!

Sincerely,
The Sup Developers
----------------------------------------------------------------
--- Errno::ENOENT from thread: main
No such file or directory - /home/ico/.sup/sync-back-ok
/home/ico/external/sup/lib/sup.rb:199:in `readlines'
/home/ico/external/sup/lib/sup.rb:199:in `check_syncback_settings'
bin/sup:156:in `<module:Redwood>'
bin/sup:73:in `<main>'
```

Workaround is to manually create .sup/sync-back-ok as en empty file.
