### PR TITLE
File.link is platform dependent

### DIFF
--- a/lib/sup/maildir.rb
+++ b/lib/sup/maildir.rb
@@ -57,7 +57,7 @@ class Maildir < Source
             f.fsync
           end
 
-          File.link tmp_path, new_path
+          File.safe_link tmp_path, new_path
           stored = true
         ensure
           File.unlink tmp_path if File.exists? tmp_path
@@ -244,9 +244,9 @@ private
       new_path  = File.join @dir, new_loc
       tmp_path  = File.join @dir, "tmp", "#{md_base}:#{md_ver},#{flags}"
 
-      File.link orig_path, tmp_path
+      File.safe_link orig_path, tmp_path
       File.unlink orig_path
-      File.link tmp_path, new_path
+      File.safe_link tmp_path, new_path
       File.unlink tmp_path
 
       new_loc

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -8,6 +8,7 @@ require 'set'
 require 'enumerator'
 require 'benchmark'
 require 'unicode'
+require 'fileutils'
 
 ## time for some monkeypatching!
 class Symbol
@@ -43,6 +44,17 @@ class Lockfile
   end
 
   def touch_yourself; touch path end
+end
+
+class File
+  # platform safe file.link which attempts a copy if hard-linking fails
+  def self.safe_link src, dest
+    begin
+      File.link src, dest
+    rescue
+      FileUtils.copy src, dest
+    end
+  end
 end
 
 class Pathname


### PR DESCRIPTION
File.link (used extensively in maildir.rb) is not available on all platforms or file systems. There should be an alternative. It fails on encfs file systems.
