### PR TITLE
Support more frequent representation of a PGP signed message

### DIFF
--- a/lib/sup/message.rb
+++ b/lib/sup/message.rb
@@ -572,7 +572,7 @@ private
   def inline_gpg_to_chunks body, encoding_to, encoding_from
     lines = body.split("\n")
 
-    # First case: Message is enclodsed between
+    # First case: Message is enclosed between
     #
     # -----BEGIN PGP SIGNED MESSAGE-----
     # and


### PR DESCRIPTION
Most PGP signed message follow the current template:

```
---- BEGIN PGP SIGNED MESSAGE -----
Hash: sha512
<The message>
----- BEGIN PGP SIGNATURE -----
<The signature>
----- END PGP SIGNATURE -----
```

This was not correctly parsed by the relevant code, so here's a proposed modification
