### PR TITLE
Add hidden alternate mails support

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,7 +5,7 @@ Whyme Lyu <callme5long at the gmail dot coms>
 Hamish Downer <dmishd at the gmail dot coms>
 Damien Leone <damien.leone at the fensalir dot frs>
 Sascha Silbe <sascha-pgp at the silbe dot orgs>
-Eric Weikl <eric.weikl at the tngtech dot coms>
+Eric Weikl <eric.weikl at the gmx dot nets>
 Ismo Puustinen <ismo at the iki dot fis>
 Nicolas Pouillard <nicolas.pouillard at the gmail dot coms>
 Michael Stapelberg <michael at the stapelberg dot des>
@@ -17,34 +17,34 @@ Clint Byrum <clint at the ubuntu dot coms>
 Marcus Williams <marcus-sup at the bar-coded dot nets>
 Lionel Ott <white.magic at the gmx dot des>
 Gaudenz Steinlin <gaudenz at the soziologie dot chs>
-Mark Alexander <marka at the pobox dot coms>
 Ingmar Vanhassel <ingmar at the exherbo dot orgs>
+Mark Alexander <marka at the pobox dot coms>
 Edward Z. Yang <ezyang at the mit dot edus>
+Matthieu Rakotojaona <matthieu.rakotojaona at the gmail dot coms>
 Christopher Warrington <chrisw at the rice dot edus>
 W. Trevor King <wking at the drexel dot edus>
 Richard Brown <rbrown at the exherbo dot orgs>
 Anthony Martinez <pi+sup at the pihost dot uss>
 Marc Hartstein <marc.hartstein at the alum.vassar dot edus>
-Matthieu Rakotojaona <matthieu.rakotojaona at the gmail dot coms>
 Israel Herraiz <israel.herraiz at the gmail dot coms>
 Bo Borgerson <gigabo at the gmail dot coms>
 Michael Hamann <michael at the content-space dot des>
-Jonathan Lassoff <jof at the thejof dot coms>
 William Erik Baxter <web at the superscript dot coms>
+Jonathan Lassoff <jof at the thejof dot coms>
 Grant Hollingworth <grant at the antiflux dot orgs>
 Adeodato Simó <dato at the net.com.org dot ess>
 Ico Doornekamp <ico at the pruts dot nls>
 Markus Klinik <markus.klinik at the gmx dot des>
 Daniel Schoepe <daniel.schoepe at the googlemail dot coms>
-Jason Petsod <jason at the petsod dot orgs>
 James Taylor <james at the jamestaylor dot orgs>
-Robin Burchell <viroteck at the viroteck dot nets>
+Jason Petsod <jason at the petsod dot orgs>
 Steve Goldman <sgoldman at the tower-research dot coms>
+Robin Burchell <viroteck at the viroteck dot nets>
 Peter Harkins <ph at the malaprop dot orgs>
 Decklin Foster <decklin at the red-bean dot coms>
 Cameron Matheson <cam+sup at the cammunism dot orgs>
-Alex Vandiver <alex at the chmrr dot nets>
 Carl Worth <cworth at the cworth dot orgs>
+Alex Vandiver <alex at the chmrr dot nets>
 Andrew Pimlott <andrew at the pimlott dot nets>
 Jeff Balogh <its.jeff.balogh at the gmail dot coms>
 Matías Aguirre <matiasaguirre at the gmail dot coms>
@@ -52,19 +52,20 @@ Kornilios Kourtis <kkourt at the cslab.ece.ntua dot grs>
 Giorgio Lando <patroclo7 at the gmail dot coms>
 Kevin Riggle <kevinr at the free-dissociation dot coms>
 Benoît PIERRE <benoit.pierre at the gmail dot coms>
-Steven Lawrance <stl at the koffein dot nets>
 Alvaro Herrera <alvherre at the alvh.no-ip dot orgs>
+Steven Lawrance <stl at the koffein dot nets>
 Jonah <Jonah at the GoodCoffee dot cas>
 ian <itaylor at the uark dot edus>
-Per Andersson <avtobiff at the gmail dot coms>
 Adam Lloyd <adam at the alloy-d dot nets>
-Todd Eisenberger <teisenbe at the andrew.cmu dot edus>
 Gregor Hoffleit <gregor at the sam.mediasupervision dot des>
+0xACE <0xACE at the users.noreply.github dot coms>
+Per Andersson <avtobiff at the gmail dot coms>
 MichaelRevell <mikearevell at the gmail dot coms>
+Todd Eisenberger <teisenbe at the andrew.cmu dot edus>
 Steven Walter <swalter at the monarch.(none)>
-Stefan Lundström <lundst at the snabb.(none)>
-Horacio Sanson <horacio at the skillupjapan.co dot jps>
-Jon M. Dugan <jdugan at the es dot nets>
-akojo <atte.kojo at the gmail dot coms>
 Matthias Vallentin <vallentin at the icir dot orgs>
+akojo <atte.kojo at the gmail dot coms>
+Jon M. Dugan <jdugan at the es dot nets>
+Horacio Sanson <horacio at the skillupjapan.co dot jps>
+Stefan Lundström <lundst at the snabb.(none)>
 Kirill Smelkov <kirr at the landau.phys.spbu dot rus>

--- a/lib/sup/version.rb
+++ b/lib/sup/version.rb
@@ -1,3 +1,3 @@
 module Redwood
-  VERSION = "0.14.1.1"
+  VERSION = "0.15.0"
 end


### PR DESCRIPTION
This small change allows users to have `:hidden_alternates` section in configuration.

Addresses in this section will never be shown when replying or composing mails but will be assigned to accounts and treated as own.
