### PR TITLE
flush temporary attachment files before viewing

### DIFF
--- a/lib/sup/message_chunks.rb
+++ b/lib/sup/message_chunks.rb
@@ -205,6 +205,7 @@ EOS
       begin
         file = Tempfile.new(["sup", Shellwords.escape(@filename.gsub("/", "_")) || "sup-attachment"])
         file.print @raw_content
+        file.flush
         yield file if block_given?
         return file.path
       ensure


### PR DESCRIPTION
I was having problems with the temporary attachment files being empty
when external programs (vim and w3m, and using system(), so blocking)
opened them from my mime-view hook. Flushing the content before yielding
in Attachment#write_to_disk fixes the problem for all the cases where I
encountered the problem.

Signed-off-by: Johannes Larsen johs.a.larsen@gmail.com
