### PR TITLE
Quick hack to pass -f to sendmail to set the envelope sender.

### DIFF
--- a/lib/sup/modes/edit_message_mode.rb
+++ b/lib/sup/modes/edit_message_mode.rb
@@ -486,6 +486,12 @@ protected
 
     acct = AccountManager.account_for(from_email) || AccountManager.default_account
     BufferManager.flash "Sending..."
+    sendmailcmd = acct.sendmail
+    
+    if sendmailcmd =~ /.*-f$/ then
+      sendmailcmd += " #{from_email}"
+    end
+    
 
     begin
       date = Time.now
@@ -497,8 +503,8 @@ protected
               return false
         end
       else
-        IO.popen(acct.sendmail, "w:UTF-8") { |p| p.puts m }
-        raise SendmailCommandFailed, "Couldn't execute #{acct.sendmail}" unless $? == 0
+        IO.popen(sendmailcmd, "w:UTF-8") { |p| p.puts m }
+        raise SendmailCommandFailed, "Couldn't execute #{sendmailcmd}" unless $? == 0
       end
 
       SentManager.write_sent_message(date, from_email) { |f| f.puts sanitize_body(m.to_s) }


### PR DESCRIPTION
Pass -f to sendmail to set the envelope sender.  This is handy for Postfix as it can target different relay servers with different authentication based on envelope sender.
