### PR TITLE
issue-233: remove the lockfile if sup isn't already launched

### DIFF
--- a/lib/sup/interactive_lock.rb
+++ b/lib/sup/interactive_lock.rb
@@ -71,6 +71,7 @@ EOS
         end
         stream.puts "Let's try that one more time."
         begin
+          sleep DELAY
           Index.lock
         rescue Index::LockError => e
           stream.puts "I couldn't unlock the index."


### PR DESCRIPTION
See the issue https://github.com/sup-heliotrope/sup/issues/233 for more information.
This is my first pull request in Ruby so you must be _very_ vigilant. Do not hesitate to inform me about errors.
