### PR TITLE
Add user defined labels in thread view mode title

### DIFF
--- a/lib/sup/modes/thread_index_mode.rb
+++ b/lib/sup/modes/thread_index_mode.rb
@@ -116,14 +116,8 @@ EOS
           m.load_from_source!
         end
       end
-
       mode = ThreadViewMode.new t, @hidden_labels, self
-      user_labels = t.labels.to_a.map do |l|
-        l.to_s if LabelManager.user_defined_labels.member?(l)
-      end.compact.join(",")
-      title = (user_labels ? "<" + user_labels + "> " : "") + t.subj
-
-      BufferManager.spawn title, mode
+      BufferManager.spawn t.subj, mode
       BufferManager.draw_screen
       mode.jump_to_first_open if $config[:jump_to_open_message]
       BufferManager.draw_screen # lame TODO: make this unnecessary

--- a/lib/sup/modes/thread_view_mode.rb
+++ b/lib/sup/modes/thread_view_mode.rb
@@ -692,6 +692,15 @@ EOS
     end
   end
 
+
+  def status
+    user_labels = @thread.labels.to_a.map do |l|
+      l.to_s if LabelManager.user_defined_labels.member?(l)
+    end.compact.join(",")
+    user_labels = (user_labels.empty? and "" or "<#{user_labels}>")
+    [user_labels, super].join(" -- ")
+  end
+
 private
 
   def initial_state_for m


### PR DESCRIPTION
Since I identify threads based on the labels in it, this little enhancement allows me to quickly remember what context I'm in. The status line now looks like that:

```
[thread-view-mode] <label1,label2> The subject of this thread    line 1 of 2
```

with label1 and label2 being user-defined labels.

This is only here for discussion. TODO:  update the status line when we modify the tags inside the `thread-view-mode`
