### PR TITLE
contact-list-mode: use sup default color instead of terminal default

### DIFF
--- a/lib/sup/modes/contact_list_mode.rb
+++ b/lib/sup/modes/contact_list_mode.rb
@@ -130,7 +130,7 @@ protected
   def text_for_contact p
     aalias = ContactManager.alias_for(p) || ""
     [[:tagged_color, @tags.tagged?(p) ? ">" : " "],
-     [:none, sprintf("%-#{@awidth}s %-#{@nwidth}s %s", aalias, p.name, p.email)]]
+     [:text_color, sprintf("%-#{@awidth}s %-#{@nwidth}s %s", aalias, p.name, p.email)]]
   end
 
   def regen_text


### PR DESCRIPTION
Addendum to https://github.com/sup-heliotrope/sup/issues/77
I found another place where sup uses the terminal default color instead
of the default text color: the contact list. With this patch, the
contact list uses colors from the colorscheme.
