### PR TITLE
person: Don't downcase the email address

### DIFF
--- a/lib/sup/person.rb
+++ b/lib/sup/person.rb
@@ -15,7 +15,7 @@ class Person
       name.gsub('\\\\', '\\')
     end
 
-    @email = email.strip.gsub(/\s+/, " ").downcase
+    @email = email.strip.gsub(/\s+/, " ")
   end
 
   def to_s; "#@name <#@email>" end


### PR DESCRIPTION
As per RFC 2821:
    The local-part of a mailbox MUST BE treated as case sensitive.
    Therefore, SMTP implementations MUST take care to preserve the case of
    mailbox local-parts. Mailbox domains are not case sensitive. In particular,
    for some hosts the user "smith" is different from the user "Smith".
