### PR TITLE
Move mark as read and archive to thread mode

### DIFF
--- a/lib/sup/modes/thread_index_mode.rb
+++ b/lib/sup/modes/thread_index_mode.rb
@@ -33,6 +33,7 @@ EOS
     k.add_multi "Load all threads (! to confirm) :", '!' do |kk|
       kk.add :load_all_threads, "Load all threads (may list a _lot_ of threads)", '!'
     end
+    k.add :read_and_archive, "Archive thread (remove from inbox) and mark read", 'A'
     k.add :cancel_search, "Cancel current search", :ctrl_g
     k.add :reload, "Refresh view", '@'
     k.add :toggle_archived, "Toggle archived status", 'a'
@@ -731,6 +732,47 @@ EOS
     end
   end
   ignore_concurrent_calls :load_threads
+
+  def read_and_archive
+    return unless cursor_thread
+    thread = cursor_thread # to make sure lambda only knows about 'old' cursor_thread
+
+    was_unread = thread.labels.member? :unread
+    UndoManager.register "reading and archiving thread" do
+      thread.apply_label :inbox
+      thread.apply_label :unread if was_unread
+      add_or_unhide thread.first
+      Index.save_thread thread
+    end
+
+    cursor_thread.remove_label :unread
+    cursor_thread.remove_label :inbox
+    hide_thread cursor_thread
+    regen_text
+    Index.save_thread thread
+  end
+
+  def multi_read_and_archive threads
+    old_labels = threads.map { |t| t.labels.dup }
+
+    threads.each do |t|
+      t.remove_label :unread
+      t.remove_label :inbox
+      hide_thread t
+    end
+    regen_text
+
+    UndoManager.register "reading and archiving #{threads.size.pluralize 'thread'}" do
+      threads.zip(old_labels).each do |t, l|
+        t.labels = l
+        add_or_unhide t.first
+        Index.save_thread t
+      end
+      regen_text
+    end
+
+    threads.each { |t| Index.save_thread t }
+  end
 
   def resize rows, cols
     regen_text


### PR DESCRIPTION
This allows me to do searches to refine the crap in my inbox, and
`<shift>-a` them right away, instead of `| => is:unread label:<blah> =>
<shift>-T =<shift>N => | -label:<blah> | <shift>-T =a`

All I did was copy over the code to Thread Index Mode and test it. Would
love to write some tests for this if required, but I couldn't find any on particular for this (with a quick grep on read_and_archive in test/)

Cheers guys, love sup :-)
