### PR TITLE
Tag by label

### DIFF
--- a/lib/sup/modes/thread_index_mode.rb
+++ b/lib/sup/modes/thread_index_mode.rb
@@ -51,6 +51,7 @@ EOS
     k.add :toggle_tagged, "Tag/untag selected thread", 't'
     k.add :toggle_tagged_all, "Tag/untag all threads", 'T'
     k.add :tag_matching, "Tag matching threads", 'g'
+    k.add :tag_labeled, "Tag/untag threads with a label", 'O'
     k.add :apply_to_tagged, "Apply next command to all tagged threads", '+', '='
     k.add :join_threads, "Force tagged threads to be joined into the same thread", '#'
     k.add :undo, "Undo the previous action", 'u'
@@ -562,6 +563,13 @@ EOS
       return
     end
     @mutex.synchronize { @threads.each { |t| @tags.tag t if thread_matches?(t, query) } }
+    regen_text
+  end
+
+  def tag_labeled
+    label = BufferManager.ask :search, "tag threads matching (label): "
+    return if label.nil? || label.empty?
+    @mutex.synchronize { @threads.each { |t| @tags.toggle_tag_for t if t.has_label? label.to_sym } }
     regen_text
   end
 


### PR DESCRIPTION
And another one :-)

Tag a thread by label in any ThreadIndexMode. My use case: Tons of dev emails from different clients (github, gitlab, appsignal, newrelic, sentry), sometimes I want to tag a subset and do whatever, without switching the buffer.

Couple points:
- Again the issue of tests; the method is trivial but I prefer to test my code (besides a user test). Preferred? Pointers?
- Keybinding O is ridiculous. I wanted to go for ctrl_t but couldn't get it to work (no binding in ncursesw and couldn't get the ord)
- I figured tagging a single label would be enough, otherwise you might as well do a more complex xapian search (given my usecase), but yours might differ, if more complexity is needed I'll fix it up.
