### PR TITLE
Make maildir protocol able to deal with path contains special characters like "[", "]", and whitespace

### DIFF
--- a/lib/sup/maildir.rb
+++ b/lib/sup/maildir.rb
@@ -119,7 +119,6 @@ class Maildir < Source
       next if prev_ctime >= ctime
       @ctimes[d] = ctime
 
-      debug subdir
       old_ids = benchmark(:maildir_read_index) { Index.instance.enum_for(:each_source_info, self.id, "#{d}/").to_a }
       new_ids = benchmark(:maildir_read_dir) {
         Dir.new("#{subdir}").entries.flat_map { |x| 


### PR DESCRIPTION
Sup had a issue that will treat maildir path with special characters as invalid. Those characters are not acceptable in URI, but valid in file path such as "[Gmail]/.All Mails". Here's a small patch to solve that issue.
