### PR TITLE
rename Singleton to SupSingleton to sidestep conflicts with ruby's Singleton

### DIFF
--- a/lib/sup/account.rb
+++ b/lib/sup/account.rb
@@ -25,7 +25,7 @@ class Account < Person
 end
 
 class AccountManager
-  include Singleton
+  include SupSingleton
 
   attr_accessor :default_account
 

--- a/lib/sup/buffer.rb
+++ b/lib/sup/buffer.rb
@@ -99,7 +99,7 @@ class Buffer
 end
 
 class BufferManager
-  include Singleton
+  include SupSingleton
 
   attr_reader :focus_buf
 

--- a/lib/sup/contact.rb
+++ b/lib/sup/contact.rb
@@ -3,7 +3,7 @@
 module Redwood
 
 class ContactManager
-  include Singleton
+  include SupSingleton
 
   def initialize fn
     @fn = fn

--- a/lib/sup/crypto.rb
+++ b/lib/sup/crypto.rb
@@ -6,7 +6,7 @@ end
 module Redwood
 
 class CryptoManager
-  include Singleton
+  include SupSingleton
 
   class Error < StandardError; end
 

--- a/lib/sup/draft.rb
+++ b/lib/sup/draft.rb
@@ -1,7 +1,7 @@
 module Redwood
 
 class DraftManager
-  include Singleton
+  include SupSingleton
 
   attr_accessor :source
   def initialize dir

--- a/lib/sup/hook.rb
+++ b/lib/sup/hook.rb
@@ -69,7 +69,7 @@ class HookManager
     end
   end
 
-  include Singleton
+  include SupSingleton
 
   @descs = {}
 

--- a/lib/sup/idle.rb
+++ b/lib/sup/idle.rb
@@ -3,7 +3,7 @@ require 'thread'
 module Redwood
 
 class IdleManager
-  include Singleton
+  include SupSingleton
 
   IDLE_THRESHOLD = 60
 

--- a/lib/sup/index.rb
+++ b/lib/sup/index.rb
@@ -55,7 +55,7 @@ EOS
     def method_missing m; @h[m.to_s] end
   end
 
-  include Singleton
+  include SupSingleton
 
   def initialize dir=BASE_DIR
     @dir = dir

--- a/lib/sup/label.rb
+++ b/lib/sup/label.rb
@@ -3,7 +3,7 @@
 module Redwood
 
 class LabelManager
-  include Singleton
+  include SupSingleton
 
   ## labels that have special semantics. user will be unable to
   ## add/remove these via normal label mechanisms.

--- a/lib/sup/logger.rb
+++ b/lib/sup/logger.rb
@@ -8,7 +8,7 @@ module Redwood
 ## also keeps a record of all messages, so that adding a new sink will send all
 ## previous messages to it by default.
 class Logger
-  include Singleton
+  include SupSingleton
 
   LEVELS = %w(debug info warn error) # in order!
 

--- a/lib/sup/poll.rb
+++ b/lib/sup/poll.rb
@@ -3,7 +3,7 @@ require 'thread'
 module Redwood
 
 class PollManager
-  include Singleton
+  include SupSingleton
 
   HookManager.register "before-add-message", <<EOS
 Executes immediately before a message is added to the index.

--- a/lib/sup/search.rb
+++ b/lib/sup/search.rb
@@ -3,7 +3,7 @@
 module Redwood
 
 class SearchManager
-  include Singleton
+  include SupSingleton
 
   class ExpansionError < StandardError; end
 

--- a/lib/sup/sent.rb
+++ b/lib/sup/sent.rb
@@ -1,7 +1,7 @@
 module Redwood
 
 class SentManager
-  include Singleton
+  include SupSingleton
 
   attr_reader :source, :source_uri
 

--- a/lib/sup/source.rb
+++ b/lib/sup/source.rb
@@ -187,7 +187,7 @@ module SerializeLabelsNicely
 end
 
 class SourceManager
-  include Singleton
+  include SupSingleton
 
   def initialize
     @sources = {}

--- a/lib/sup/undo.rb
+++ b/lib/sup/undo.rb
@@ -8,7 +8,7 @@ module Redwood
 ## undo the archival action
 
 class UndoManager
-  include Singleton
+  include SupSingleton
 
   def initialize
     @@actionlist = []

--- a/lib/sup/update.rb
+++ b/lib/sup/update.rb
@@ -12,7 +12,7 @@ module Redwood
 ## single "view". Luckily, that's true.)
 
 class UpdateManager
-  include Singleton
+  include SupSingleton
 
   def initialize
     @targets = {}

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -632,7 +632,7 @@ end
 ## classes that inherit this can define initialize. however, you cannot call
 ## .new on the class. To get the instance of the class, call .instance;
 ## to create the instance, call init.
-module Singleton
+module SupSingleton
   module ClassMethods
     def instance; @instance; end
     def instantiated?; defined?(@instance) && !@instance.nil?; end

--- a/lib/sup/util/ncurses.rb
+++ b/lib/sup/util/ncurses.rb
@@ -116,7 +116,7 @@ module Ncurses
     # Empty singleton that
     # keeps GC from going crazy.
     class Empty < CharCode
-      include Singleton
+      include SupSingleton
 
       ## Wrap methods that may change us
       ## and generate new object instead.


### PR DESCRIPTION
@eMBee's conversion from Singleton to SupSingleton to make sure there is no conflict with Rubys orignal. The Mail library uses Rubys and things get a little messed up.
