### PR TITLE
Make Sup's singleton part of the Redwood module

### DIFF
--- a/lib/sup/account.rb
+++ b/lib/sup/account.rb
@@ -25,7 +25,7 @@ class Account < Person
 end
 
 class AccountManager
-  include SupSingleton
+  include Singleton
 
   attr_accessor :default_account
 

--- a/lib/sup/buffer.rb
+++ b/lib/sup/buffer.rb
@@ -99,7 +99,7 @@ class Buffer
 end
 
 class BufferManager
-  include SupSingleton
+  include Singleton
 
   attr_reader :focus_buf
 

--- a/lib/sup/contact.rb
+++ b/lib/sup/contact.rb
@@ -3,7 +3,7 @@
 module Redwood
 
 class ContactManager
-  include SupSingleton
+  include Singleton
 
   def initialize fn
     @fn = fn

--- a/lib/sup/crypto.rb
+++ b/lib/sup/crypto.rb
@@ -6,7 +6,7 @@ end
 module Redwood
 
 class CryptoManager
-  include SupSingleton
+  include Singleton
 
   class Error < StandardError; end
 

--- a/lib/sup/draft.rb
+++ b/lib/sup/draft.rb
@@ -1,7 +1,7 @@
 module Redwood
 
 class DraftManager
-  include SupSingleton
+  include Singleton
 
   attr_accessor :source
   def initialize dir

--- a/lib/sup/hook.rb
+++ b/lib/sup/hook.rb
@@ -69,7 +69,7 @@ class HookManager
     end
   end
 
-  include SupSingleton
+  include Singleton
 
   @descs = {}
 

--- a/lib/sup/idle.rb
+++ b/lib/sup/idle.rb
@@ -3,7 +3,7 @@ require 'thread'
 module Redwood
 
 class IdleManager
-  include SupSingleton
+  include Singleton
 
   IDLE_THRESHOLD = 60
 

--- a/lib/sup/index.rb
+++ b/lib/sup/index.rb
@@ -55,7 +55,7 @@ EOS
     def method_missing m; @h[m.to_s] end
   end
 
-  include SupSingleton
+  include Singleton
 
   def initialize dir=BASE_DIR
     @dir = dir

--- a/lib/sup/label.rb
+++ b/lib/sup/label.rb
@@ -3,7 +3,7 @@
 module Redwood
 
 class LabelManager
-  include SupSingleton
+  include Singleton
 
   ## labels that have special semantics. user will be unable to
   ## add/remove these via normal label mechanisms.

--- a/lib/sup/logger.rb
+++ b/lib/sup/logger.rb
@@ -8,7 +8,7 @@ module Redwood
 ## also keeps a record of all messages, so that adding a new sink will send all
 ## previous messages to it by default.
 class Logger
-  include SupSingleton
+  include Singleton
 
   LEVELS = %w(debug info warn error) # in order!
 

--- a/lib/sup/poll.rb
+++ b/lib/sup/poll.rb
@@ -3,7 +3,7 @@ require 'thread'
 module Redwood
 
 class PollManager
-  include SupSingleton
+  include Singleton
 
   HookManager.register "before-add-message", <<EOS
 Executes immediately before a message is added to the index.

--- a/lib/sup/search.rb
+++ b/lib/sup/search.rb
@@ -3,7 +3,7 @@
 module Redwood
 
 class SearchManager
-  include SupSingleton
+  include Singleton
 
   class ExpansionError < StandardError; end
 

--- a/lib/sup/sent.rb
+++ b/lib/sup/sent.rb
@@ -1,7 +1,7 @@
 module Redwood
 
 class SentManager
-  include SupSingleton
+  include Singleton
 
   attr_reader :source, :source_uri
 

--- a/lib/sup/singleton.rb
+++ b/lib/sup/singleton.rb
@@ -1,0 +1,44 @@
+## simple singleton module. far less complete and insane than the ruby standard
+## library one, but it automatically forwards methods calls and allows for
+## constructors that take arguments.
+##
+## classes that inherit this can define initialize. however, you cannot call
+## .new on the class. To get the instance of the class, call .instance;
+## to create the instance, call init.
+module Redwood
+  module Singleton
+    module ClassMethods
+      def instance; @instance; end
+      def instantiated?; defined?(@instance) && !@instance.nil?; end
+      def deinstantiate!; @instance = nil; end
+      def method_missing meth, *a, &b
+        raise "no #{name} instance defined in method call to #{meth}!" unless defined? @instance
+
+        ## if we've been deinstantiated, just drop all calls. this is
+        ## useful because threads that might be active during the
+        ## cleanup process (e.g. polling) would otherwise have to
+        ## special-case every call to a Singleton object
+        return nil if @instance.nil?
+
+        # Speed up further calls by defining a shortcut around method_missing
+        if meth.to_s[-1,1] == '='
+          # Argh! Inconsistency! Setters do not work like all the other methods.
+          class_eval "def self.#{meth}(a); @instance.send :#{meth}, a; end"
+        else
+          class_eval "def self.#{meth}(*a, &b); @instance.send :#{meth}, *a, &b; end"
+        end
+
+        @instance.send meth, *a, &b
+      end
+      def init *args
+        raise "there can be only one! (instance)" if instantiated?
+        @instance = new(*args)
+      end
+    end
+
+    def self.included klass
+      klass.private_class_method :allocate, :new
+      klass.extend ClassMethods
+    end
+  end
+end

--- a/lib/sup/source.rb
+++ b/lib/sup/source.rb
@@ -187,7 +187,7 @@ module SerializeLabelsNicely
 end
 
 class SourceManager
-  include SupSingleton
+  include Singleton
 
   def initialize
     @sources = {}

--- a/lib/sup/undo.rb
+++ b/lib/sup/undo.rb
@@ -8,7 +8,7 @@ module Redwood
 ## undo the archival action
 
 class UndoManager
-  include SupSingleton
+  include Singleton
 
   def initialize
     @@actionlist = []

--- a/lib/sup/update.rb
+++ b/lib/sup/update.rb
@@ -12,7 +12,7 @@ module Redwood
 ## single "view". Luckily, that's true.)
 
 class UpdateManager
-  include SupSingleton
+  include Singleton
 
   def initialize
     @targets = {}

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -625,49 +625,6 @@ class Array
   def nonempty?; !empty? end
 end
 
-## simple singleton module. far less complete and insane than the ruby standard
-## library one, but it automatically forwards methods calls and allows for
-## constructors that take arguments.
-##
-## classes that inherit this can define initialize. however, you cannot call
-## .new on the class. To get the instance of the class, call .instance;
-## to create the instance, call init.
-module SupSingleton
-  module ClassMethods
-    def instance; @instance; end
-    def instantiated?; defined?(@instance) && !@instance.nil?; end
-    def deinstantiate!; @instance = nil; end
-    def method_missing meth, *a, &b
-      raise "no #{name} instance defined in method call to #{meth}!" unless defined? @instance
-
-      ## if we've been deinstantiated, just drop all calls. this is
-      ## useful because threads that might be active during the
-      ## cleanup process (e.g. polling) would otherwise have to
-      ## special-case every call to a Singleton object
-      return nil if @instance.nil?
-
-      # Speed up further calls by defining a shortcut around method_missing
-      if meth.to_s[-1,1] == '='
-        # Argh! Inconsistency! Setters do not work like all the other methods.
-        class_eval "def self.#{meth}(a); @instance.send :#{meth}, a; end"
-      else
-        class_eval "def self.#{meth}(*a, &b); @instance.send :#{meth}, *a, &b; end"
-      end
-
-      @instance.send meth, *a, &b
-    end
-    def init *args
-      raise "there can be only one! (instance)" if instantiated?
-      @instance = new(*args)
-    end
-  end
-
-  def self.included klass
-    klass.private_class_method :allocate, :new
-    klass.extend ClassMethods
-  end
-end
-
 ## acts like a hash with an initialization block, but saves any
 ## newly-created value even upon lookup.
 ##

--- a/lib/sup/util/ncurses.rb
+++ b/lib/sup/util/ncurses.rb
@@ -1,5 +1,6 @@
 require 'ncursesw'
 require 'sup/util'
+require 'sup/singleton'
 
 if defined? Ncurses
 module Ncurses
@@ -116,7 +117,7 @@ module Ncurses
     # Empty singleton that
     # keeps GC from going crazy.
     class Empty < CharCode
-      include SupSingleton
+      include Redwood::Singleton
 
       ## Wrap methods that may change us
       ## and generate new object instead.


### PR DESCRIPTION
Revert e61c1b9 and put `Singleton` in its own file under the `Redwood` module.

I have no strong feeling against the alternative (`Redwood::Util`), I just thought `Util` should be reserved for monkey-patching. Here we just have a whole new class.
