### PR TITLE
New hooks when opening thread-view: determine inital state and modify threads

### DIFF
--- a/lib/sup/modes/thread_view_mode.rb
+++ b/lib/sup/modes/thread_view_mode.rb
@@ -58,6 +58,15 @@ EOS
     state:   either :open or :close (default)
 EOS
 
+  HookManager.register "thread-view-opened", <<EOS
+  Executed when a thread is opened
+
+  Variables:
+    thread: thread object with messages (where they exist)
+  Return value:
+    None.
+EOS
+
   register_keymap do |k|
     k.add :toggle_detailed_header, "Toggle detailed header", 'h'
     k.add :show_header, "Show full message header", 'H'
@@ -129,6 +138,7 @@ EOS
 
   def initialize thread, hidden_labels=[], index_mode=nil
     super :slip_rows => $config[:slip_rows]
+    HookManager.run "thread-view-opened", :thread => thread
     @thread = thread
     @hidden_labels = hidden_labels
 


### PR DESCRIPTION
One hook is run upon opening the thread, so you can loop over the
messages and make modifications upon opening the thread:

Description:
  "thread-view-opened"
  Executed when a thread is opened

  Variables:
    thread: thread object with messages (where they exist)
  Return value:
    None.

Unuseful example:

``` rb
log "got thread: #{thread}"

thread.each do |m,d,p|
  next unless m

  log "message: #{m}"

  if m.has_label? :read
    log "message: #{m} is :read"
  end
end

```

Next is: message-initial-state, determine whether a message should be
toggled opened or closed.

Description:
  "message-initial-state"
  Executed when determining whether a message should be open
  or closed when rendering a thread.

  The default behaviour is that :unread and :starred messages
  are open.

  Variables:
    message: message to be rendered
  Return value:
    state:   either :open or :close (default)

Unuseful example, always open all threads:

``` rb
log "got message: #{message}"

state = :open # yup, all open


state
```
