### PR TITLE
Fix ensure_maildir

### DIFF
--- a/bin/sup-add
+++ b/bin/sup-add
@@ -106,7 +106,7 @@ begin
       when "maildir"
         Redwood::Maildir.new uri, !$opts[:unusual], $opts[:archive], nil, labels
       when "maildirroot"
-        Redwood::MaildirRoot.new uri, !$opts[:unusual], $opts[:archive], nil, labels
+        Redwood::MaildirRoot.new uri, !$opts[:unusual], $opts[:archive], nil, labels, false, true, true
       when "mbox"
         Redwood::MBox.new uri, !$opts[:unusual], $opts[:archive], nil, labels
       when nil

--- a/lib/sup/maildirroot.rb
+++ b/lib/sup/maildirroot.rb
@@ -1,5 +1,6 @@
 require 'uri'
 require 'set'
+require 'fileutils'
 
 module Redwood
 
@@ -43,6 +44,8 @@ module Redwood
 
 class MaildirRoot < Source
   include SerializeLabelsNicely
+
+  attr_reader :confirm_enable_experimental, :maildir_creation_allowed
 
   ## remind me never to use inheritance again.
   yaml_properties :uri, :usual, :archived, :id, :labels, :sync_back,
@@ -150,13 +153,12 @@ class MaildirRoot < Source
     def ensure_maildir
       return if File.directory? @dir
 
-      check_enable_experimental
-      return unless @maildir_creation_allowed
+      @maildirroot.check_enable_experimental
+      return unless @maildirroot.maildir_creation_allowed
 
-      Dir.mkdir_p @dir, 0700
       ['cur', 'new', 'tmp'].each do |sub|
         next if File.directory?(File.join(@dir, sub))
-        Dir.mkdir(File.join(@dir, sub), 0700)
+        FileUtils.mkdir_p(File.join(@dir, sub))
       end
     end
 


### PR DESCRIPTION
Fixes Steven Schmeier's error as discussed in sup-devel:

``` shell
      undefined local variable or method `check_enable_experimental' for MaildirSub (deleted):Redwood::MaildirRoot::MaildirSub
      /usr/local/Cellar/ruby193/1.9.3-p545/lib/ruby/gems/1.9.1/gems/sup-999/lib/sup/maildirroot.rb:153:in `ensure_maildir' 
```
