### PR TITLE
completion-mode: correctly set completion character

### DIFF
--- a/lib/sup/buffer.rb
+++ b/lib/sup/buffer.rb
@@ -547,7 +547,7 @@ EOS
         kill_buffer completion_buf if completion_buf
 
         shorts = tf.completions.map { |full, short| short }
-        prefix_len = shorts.shared_prefix.length
+        prefix_len = shorts.shared_prefix(caseless=true).length
 
         mode = CompletionMode.new shorts, :header => "Possible completions for \"#{tf.value}\": ", :prefix_len => prefix_len
         completion_buf = spawn "<completions>", mode, :height => 10


### PR DESCRIPTION
Auto completion is case-insensitive. Calculation of the completion
character must be case-insensitive as well.

Otherwise, if you have two labels "bar" and "Baz", and you type

```
Lba<Tab>
```

the letters 'b' and 'B' are marked, when really 'r' and 'z' should be
marked. The same goes for contacts with an initial segment that differs
only in case.
