### PR TITLE
ctrl-n, ctrl-p: don't close message if there is no next one

### DIFF
--- a/lib/sup/modes/thread_view_mode.rb
+++ b/lib/sup/modes/thread_view_mode.rb
@@ -454,13 +454,15 @@ EOS
     m = (curpos ... @message_lines.length).argfind { |i| @message_lines[i] }
     return unless m
 
+    nextm = @layout[m].next
+    return unless nextm
+
     if @layout[m].toggled_state == true
       @layout[m].state = :closed
       @layout[m].toggled_state = false
       update
     end
 
-    nextm = @layout[m].next
     if @layout[nextm].state == :closed
       @layout[nextm].state = :open
       @layout[nextm].toggled_state = true
@@ -491,13 +493,15 @@ EOS
     m = (0 .. curpos).to_a.reverse.argfind { |i| @message_lines[i] }
     return unless m
 
+    nextm = @layout[m].prev
+    return unless nextm
+
     if @layout[m].toggled_state == true
       @layout[m].state = :closed
       @layout[m].toggled_state = false
       update
     end
 
-    nextm = @layout[m].prev
     if @layout[nextm].state == :closed
       @layout[nextm].state = :open
       @layout[nextm].toggled_state = true


### PR DESCRIPTION
This fixes the following inconsistent behaviour.
- have a thread with multiple messages

old behaviour:
1. close all messages
2. move cursor on a later message
3. repeatedly press ctrl-p until you reach the first message
4. pressing ctrl-p one more time closes the first message again

Step 4. should not close the message. In fact, if you close all but the
first message in step 1, then step 4 doesn't close the message. This is
inconsistent.

new behaviour:

The first message stays open when you press ctrl-p, no matter if it was
opened or closed before.

Analoguous for ctrl-n and the last message in a thread.
