### PR TITLE
Fix: sync_back on new messages to preserve modifications to labels in before-add-message hook

### DIFF
--- a/lib/sup/poll.rb
+++ b/lib/sup/poll.rb
@@ -224,7 +224,7 @@ EOS
               m = source.ensure_in_archive m
             end
 
-            Index.sync_message m, true, false
+            Index.sync_message m, true, !old_m 
 
             if old_m
               # if a message has been modified send the :updated signal


### PR DESCRIPTION
Fix issue: https://github.com/sup-heliotrope/sup/issues/296

Add call to Message#sync_back from within Index#sync_message for new messages.
