### PR TITLE
sup-tweak-labels: sync back if specified

### DIFF
--- a/bin/sup-tweak-labels
+++ b/bin/sup-tweak-labels
@@ -64,6 +64,7 @@ Trollop::die "nothing to do: no labels to add or remove" if add_labels.empty? &&
 Redwood::start
 index = Redwood::Index.init
 index.lock_interactively or exit
+
 begin
   index.load
 


### PR DESCRIPTION
RE: #295

sup-tweak will only sync back if

1 - :sync_back_to_maildir is set to true (in `~/.sup/config.yml`)
2 - sup-tweak was ran with the option `--sync-back`
3 - The modified email comes from a source with sync_back enabled (in `~/.sup/sources.yml`)
