### PR TITLE
thread_view_mode: Kill a message (and next, prev etc..)

### DIFF
--- a/lib/sup/modes/thread_index_mode.rb
+++ b/lib/sup/modes/thread_index_mode.rb
@@ -236,6 +236,13 @@ EOS
     update
   end
 
+  def handle_killed_update sender, m
+    t = @ts_mutex.synchronize { @ts.thread_for m }
+    return unless t
+    hide_thread t
+    update
+  end
+
   def handle_spammed_update sender, m
     t = @ts_mutex.synchronize { @ts.thread_for m }
     return unless t
@@ -244,6 +251,10 @@ EOS
   end
 
   def handle_undeleted_update sender, m
+    add_or_unhide m
+  end
+
+  def handle_unkilled_update sender, m
     add_or_unhide m
   end
 

--- a/lib/sup/modes/thread_view_mode.rb
+++ b/lib/sup/modes/thread_view_mode.rb
@@ -78,11 +78,13 @@ EOS
 
     k.add :archive_and_next, "Archive this thread, kill buffer, and view next", 'a'
     k.add :delete_and_next, "Delete this thread, kill buffer, and view next", 'd'
+    k.add :kill_and_next, "Kill this thread, kill buffer, and view next", '&'
     k.add :toggle_wrap, "Toggle wrapping of text", 'w'
 
     k.add_multi "(a)rchive/(d)elete/mark as (s)pam/mark as u(N)read:", '.' do |kk|
       kk.add :archive_and_kill, "Archive this thread and kill buffer", 'a'
       kk.add :delete_and_kill, "Delete this thread and kill buffer", 'd'
+      kk.add :kill_and_kill, "Kill this thread and kill buffer", '&'
       kk.add :spam_and_kill, "Mark this thread as spam and kill buffer", 's'
       kk.add :unread_and_kill, "Mark this thread as unread and kill buffer", 'N'
       kk.add :do_nothing_and_kill, "Just kill this buffer", '.'
@@ -91,6 +93,7 @@ EOS
     k.add_multi "(a)rchive/(d)elete/mark as (s)pam/mark as u(N)read/do (n)othing:", ',' do |kk|
       kk.add :archive_and_next, "Archive this thread, kill buffer, and view next", 'a'
       kk.add :delete_and_next, "Delete this thread, kill buffer, and view next", 'd'
+      kk.add :kill_and_next, "Kill this thread, kill buffer, and view next", '&'
       kk.add :spam_and_next, "Mark this thread as spam, kill buffer, and view next", 's'
       kk.add :unread_and_next, "Mark this thread as unread, kill buffer, and view next", 'N'
       kk.add :do_nothing_and_next, "Kill buffer, and view next", 'n', ','
@@ -99,6 +102,7 @@ EOS
     k.add_multi "(a)rchive/(d)elete/mark as (s)pam/mark as u(N)read/do (n)othing:", ']' do |kk|
       kk.add :archive_and_prev, "Archive this thread, kill buffer, and view previous", 'a'
       kk.add :delete_and_prev, "Delete this thread, kill buffer, and view previous", 'd'
+      kk.add :kill_and_prev, "Kill this thread, kill buffer, and view previous", '&'
       kk.add :spam_and_prev, "Mark this thread as spam, kill buffer, and view previous", 's'
       kk.add :unread_and_prev, "Mark this thread as unread, kill buffer, and view previous", 'N'
       kk.add :do_nothing_and_prev, "Kill buffer, and view previous", 'n', ']'
@@ -581,18 +585,21 @@ EOS
   def archive_and_kill; archive_and_then :kill end
   def spam_and_kill; spam_and_then :kill end
   def delete_and_kill; delete_and_then :kill end
+  def kill_and_kill; kill_and_then :kill end
   def unread_and_kill; unread_and_then :kill end
   def do_nothing_and_kill; do_nothing_and_then :kill end
 
   def archive_and_next; archive_and_then :next end
   def spam_and_next; spam_and_then :next end
   def delete_and_next; delete_and_then :next end
+  def kill_and_next; kill_and_then :next end
   def unread_and_next; unread_and_then :next end
   def do_nothing_and_next; do_nothing_and_then :next end
 
   def archive_and_prev; archive_and_then :prev end
   def spam_and_prev; spam_and_then :prev end
   def delete_and_prev; delete_and_then :prev end
+  def kill_and_prev; kill_and_then :prev end
   def unread_and_prev; unread_and_then :prev end
   def do_nothing_and_prev; do_nothing_and_then :prev end
 
@@ -631,6 +638,19 @@ EOS
         @thread.remove_label :deleted
         Index.save_thread @thread
         UpdateManager.relay self, :undeleted, @thread.first
+      end
+    end
+  end
+
+  def kill_and_then op
+    dispatch op do
+      @thread.apply_label :killed
+      UpdateManager.relay self, :killed, @thread.first
+      Index.save_thread @thread
+      UndoManager.register "killed 1 thread" do
+        @thread.remove_label :killed
+        Index.save_thread @thread
+        UpdateManager.relay self, :unkilled, @thread.first
       end
     end
   end


### PR DESCRIPTION
This adds the keystroke `&` to thread view mode so we can kill a thread while we're reading it.
