### PR TITLE
Display times in 24h format if configured so

### DIFF
--- a/bin/sup-config
+++ b/bin/sup-config
@@ -149,11 +149,14 @@ alts = axe("Alternate email addresses", account[:alternates].join(" ")).split(/\
 sigfn = axe "What file contains your signature?", account[:signature]
 editor = axe "What editor would you like to use?", $config[:editor]
 
+time_mode = axe "Would like to display time in 12h (type 12h) or in 24h (type 24h)?", $config[:time_mode]
+
 $config[:accounts][:default][:name] = name
 $config[:accounts][:default][:email] = email
 $config[:accounts][:default][:alternates] = alts
 $config[:accounts][:default][:signature] = sigfn
 $config[:editor] = editor
+$config[:time_mode] = time_mode
 
 done = false
 until done

--- a/lib/sup/modes/thread_view_mode.rb
+++ b/lib/sup/modes/thread_view_mode.rb
@@ -10,7 +10,6 @@ class ThreadViewMode < LineCursorMode
     attr_accessor :state
   end
 
-  DATE_FORMAT = "%B %e %Y %l:%M%p"
   INDENT_SPACES = 2 # how many spaces to indent child messages
 
   HookManager.register "detailed-headers", <<EOS
@@ -849,7 +848,7 @@ private
       end
 
       headers = OrderedHash.new
-      headers["Date"] = "#{m.date.strftime DATE_FORMAT} (#{m.date.to_nice_distance_s})"
+      headers["Date"] = "#{m.date.to_message_nice_s} (#{m.date.to_nice_distance_s})"
       headers["Subject"] = m.subj
 
       show_labels = @thread.labels - LabelManager::HIDDEN_RESERVED_LABELS
@@ -857,7 +856,7 @@ private
         headers["Labels"] = show_labels.map { |x| x.to_s }.sort.join(', ')
       end
       if parent
-        headers["In reply to"] = "#{parent.from.mediumname}'s message of #{parent.date.strftime DATE_FORMAT}"
+        headers["In reply to"] = "#{parent.from.mediumname}'s message of #{parent.date.to_message_nice_s}"
       end
 
       HookManager.run "detailed-headers", :message => m, :headers => headers

--- a/lib/sup/time.rb
+++ b/lib/sup/time.rb
@@ -60,6 +60,8 @@ EOS
   end
 
   TO_NICE_S_MAX_LEN = 9 # e.g. "Yest.10am"
+
+  ## This is how a thread date is displayed in thread-index-mode
   def to_nice_s from=Time.now
     Redwood::HookManager.run("time-to-nice-string", :time => self, :from => from) || default_to_nice_s(from)
   end
@@ -71,13 +73,21 @@ EOS
       strftime "%b %e"
     else
       if is_the_same_day? from
-        strftime("%l:%M%p").downcase # emulate %P (missing on ruby 1.8 darwin)
+        format = $config[:time_mode] == "24h" ? "%k:%M" : "%l:%M%p"
+        strftime(format).downcase
       elsif is_the_day_before? from
-        "Yest."  + nearest_hour.strftime("%l%p").downcase # emulate %P
+        format = $config[:time_mode] == "24h" ? "%kh" : "%l%p"
+        "Yest." + nearest_hour.strftime(format).downcase
       else
         strftime "%b %e"
       end
     end
+  end
+
+  ## This is how a message date is displayed in thread-view-mode
+  def to_message_nice_s from=Time.now
+    format = $config[:time_mode] == "24h" ? "%B %e %Y %k:%M" : "%B %e %Y %l:%M%p"
+    strftime format
   end
 end
 


### PR DESCRIPTION
Adds the possibility to define a `time_mode` knob in the config, which is empty by default. If its value is `24h`, the times will be displayed accordingly.
