### PR TITLE
Implement drafts for all sources

### DIFF
--- a/lib/sup/draft.rb
+++ b/lib/sup/draft.rb
@@ -20,10 +20,9 @@ class DraftManager
     PollManager.poll_from @source
   end
 
+  # This works for all sources, not only sup://drafts
   def discard m
-    raise ArgumentError, "not a draft: source id #{m.source.id.inspect}, should be #{DraftManager.source_id.inspect} for #{m.id.inspect}" unless m.source.id.to_i == DraftManager.source_id
-    Index.delete m.id
-    File.delete @source.fn_for_offset(m.source_info) rescue Errono::ENOENT
+    m.remove_label :draft
     UpdateManager.relay self, :single_message_deleted, m
   end
 end

--- a/lib/sup/maildir.rb
+++ b/lib/sup/maildir.rb
@@ -193,6 +193,10 @@ class Maildir < Source
     File.exists? File.join(@dir, id)
   end
 
+  def fn_for_offset offset
+    return File.join(@dir, offset)
+  end
+
 private
 
   def new_maildir_basefn


### PR DESCRIPTION
We just have to provide the relevant filename for the message to edit,
and then remove the `:draft` label from the message when all is done.

To test:
- Add a draft _in your remote server_
- Sync to local index
- Edit draft

Should solve #220
