### PR TITLE
ti: don't update thread line when thread is empty.

### DIFF
--- a/lib/sup/modes/thread_index_mode.rb
+++ b/lib/sup/modes/thread_index_mode.rb
@@ -856,6 +856,12 @@ protected
     need_update = false
 
     @mutex.synchronize do
+      # and certainly not sure why this happens..
+      #
+      # probably a race condition between thread modification and updating
+      # going on.
+      return if @threads[l].empty?
+
       @size_widgets[l] = size_widget_for_thread @threads[l]
       @date_widgets[l] = date_widget_for_thread @threads[l]
 


### PR DESCRIPTION
there is most likely a race condition going on between updateing the
threads and updating the lines in the buffer. just return and skip
updating line if the thread that is set for the line is empty.

fixes #190.
