### PR TITLE
Wrap piping command inside a begin/rescue to catch invalid commands

### DIFF
--- a/lib/sup/modes/text_mode.rb
+++ b/lib/sup/modes/text_mode.rb
@@ -24,8 +24,13 @@ class TextMode < ScrollMode
     command = BufferManager.ask(:shell, "pipe command: ")
     return if command.nil? || command.empty?
 
-    output = pipe_to_process(command) do |stream|
+    output, success = pipe_to_process(command) do |stream|
       @text.each { |l| stream.puts l }
+    end
+
+    unless success
+      BufferManager.flash "Invalid command: '#{command}' is not an executable"
+      return
     end
 
     if output

--- a/lib/sup/modes/thread_view_mode.rb
+++ b/lib/sup/modes/thread_view_mode.rb
@@ -722,12 +722,17 @@ EOS
     command = BufferManager.ask(:shell, "pipe command: ")
     return if command.nil? || command.empty?
 
-    output = pipe_to_process(command) do |stream|
+    output, success = pipe_to_process(command) do |stream|
       if chunk
         stream.print chunk.raw_content
       else
         message.each_raw_message_line { |l| stream.print l }
       end
+    end
+
+    unless success
+      BufferManager.flash "Invalid command: '#{command}' is not an executable"
+      return
     end
 
     if output


### PR DESCRIPTION
Fixes #341

I'm not too sure about catching `Errno::ENOENT` (It's a pretty generic error and may be thrown on other occasions) but it does the trick.
