### PR TITLE
buffer is nil sometimes, just ignore

### DIFF
--- a/lib/sup/modes/line_cursor_mode.rb
+++ b/lib/sup/modes/line_cursor_mode.rb
@@ -65,7 +65,7 @@ protected
   def set_cursor_pos p
     return if @curpos == p
     @curpos = p.clamp @cursor_top, lines
-    buffer.mark_dirty
+    buffer.mark_dirty if buffer
     set_status
   end
 

--- a/lib/sup/modes/thread_index_mode.rb
+++ b/lib/sup/modes/thread_index_mode.rb
@@ -1026,7 +1026,7 @@ private
   end
 
   def from_width
-    [(buffer.content_width.to_f * 0.2).to_i, MIN_FROM_WIDTH].max
+    [(buffer.content_width.to_f * 0.2).to_i, MIN_FROM_WIDTH].max if buffer else MIN_FROM_WIDTH
   end
 
   def initialize_threads


### PR DESCRIPTION
We end up with nil buffers sometimes, this is admittedly a hack, does it fix #344 and #345? 
