### PR TITLE
Test draft source and edit_message_mode

### DIFF
--- a/lib/sup.rb
+++ b/lib/sup.rb
@@ -61,6 +61,25 @@ module Redwood
   LOG_FN     = File.join(BASE_DIR, "log")
   SYNC_OK_FN = File.join(BASE_DIR, "sync-back-ok")
 
+  def load_constants base_dir
+    # we're cheating
+    warn "setting base directory to: #{base_dir}" if base_dir
+    BASE_DIR.replace base_dir || ENV["SUP_BASE"] || File.join(ENV["HOME"], ".sup")
+    CONFIG_FN.replace File.join(BASE_DIR, "config.yaml")
+    COLOR_FN.replace  File.join(BASE_DIR, "colors.yaml")
+    SOURCE_FN.replace File.join(BASE_DIR, "sources.yaml")
+    LABEL_FN.replace File.join(BASE_DIR, "labels.txt")
+    CONTACT_FN.replace File.join(BASE_DIR, "contacts.txt")
+    DRAFT_DIR.replace File.join(BASE_DIR, "drafts")
+    SENT_FN.replace File.join(BASE_DIR, "sent.mbox")
+    LOCK_FN.replace File.join(BASE_DIR, "lock")
+    SUICIDE_FN.replace File.join(BASE_DIR, "please-kill-yourself")
+    HOOK_DIR.replace File.join(BASE_DIR, "hooks")
+    SEARCH_FN.replace File.join(BASE_DIR, "searches.txt")
+    LOG_FN.replace File.join(BASE_DIR, "log")
+    SYNC_OK_FN.replace File.join(BASE_DIR, "sync-back-ok")
+  end
+
   YAML_DOMAIN = "supmua.org"
   LEGACY_YAML_DOMAIN = "masanjin.net"
   YAML_DATE = "2006-10-01"

--- a/lib/sup/draft.rb
+++ b/lib/sup/draft.rb
@@ -16,7 +16,7 @@ class DraftManager
   def write_draft
     offset = @source.gen_offset
     fn = @source.fn_for_offset offset
-    File.open(fn, "w") { |f| yield f }
+    File.open(fn, "w:UTF-8") { |f| yield f }
     PollManager.poll_from @source
   end
 
@@ -85,7 +85,7 @@ class DraftLoader < Source
 
   def raw_header offset
     ret = ""
-    File.open fn_for_offset(offset) do |f|
+    File.open(fn_for_offset(offset), "r:UTF-8") do |f|
       until f.eof? || (l = f.gets) =~ /^$/
         ret += l
       end
@@ -94,13 +94,13 @@ class DraftLoader < Source
   end
 
   def each_raw_message_line offset
-    File.open(fn_for_offset(offset)) do |f|
+    File.open(fn_for_offset(offset), "r:UTF-8") do |f|
       yield f.gets until f.eof?
     end
   end
 
   def raw_message offset
-    IO.read(fn_for_offset(offset))
+    IO.read(fn_for_offset(offset), :encoding => "UTF-8")
   end
 
   def start_offset; 0; end

--- a/lib/sup/modes/edit_message_mode.rb
+++ b/lib/sup/modes/edit_message_mode.rb
@@ -475,7 +475,7 @@ protected
   end
   def parse_header k,v; self.class.parse_header k,v; end
 
-  def format_headers header
+  def self.format_headers header
     header_lines = []
     headers = (FORCE_HEADERS + (header.keys - FORCE_HEADERS)).map do |h|
       lines = make_lines "#{h}:", header[h]
@@ -484,8 +484,9 @@ protected
     end.flatten.compact
     [headers, header_lines]
   end
+  def format_headers header; self.class.format_headers header; end
 
-  def make_lines header, things
+  def self.make_lines header, things
     case things
     when nil, []
       [header + " "]
@@ -506,6 +507,7 @@ protected
       end
     end
   end
+  def make_lines header, things; self.class.make_lines header, things; end
 
   def send_message
     return false if !edited? && !BufferManager.ask_yes_or_no("Message unedited. Really send?")
@@ -670,9 +672,10 @@ protected
 
 private
 
-  def sanitize_body body
+  def self.sanitize_body body
     body.gsub(/^From /, ">From ")
   end
+  def sanitize_body body; self.class.sanitize_body body; end
 
   def mentions_attachments?
     if HookManager.enabled? "mentions-attachments"

--- a/lib/sup/modes/edit_message_mode.rb
+++ b/lib/sup/modes/edit_message_mode.rb
@@ -451,7 +451,7 @@ protected
     end
   end
 
-  def parse_file fn
+  def self.parse_file fn
     File.open(fn) do |f|
       header = Source.parse_raw_email_header(f).inject({}) { |h, (k, v)| h[k.capitalize] = v; h } # lousy HACK
       body = f.readlines.map { |l| l.chomp }
@@ -462,8 +462,9 @@ protected
       [header, body]
     end
   end
+  def parse_file fn; self.class.parse_file fn; end
 
-  def parse_header k, v
+  def self.parse_header k, v
     if MULTI_HEADERS.include?(k)
       v.split_on_commas.map do |name|
         (p = ContactManager.contact_for(name)) && p.full_address || name
@@ -472,6 +473,7 @@ protected
       v
     end
   end
+  def parse_header k,v; self.class.parse_header k,v; end
 
   def format_headers header
     header_lines = []

--- a/test/integration/test_edit_message_mode.rb
+++ b/test/integration/test_edit_message_mode.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require "test_helper"
 
 class TestEditMessageAndDraft < MiniTest::Unit::TestCase

--- a/test/integration/test_edit_message_mode.rb
+++ b/test/integration/test_edit_message_mode.rb
@@ -1,0 +1,179 @@
+require "test_helper"
+
+class TestEditMessageAndDraft < MiniTest::Unit::TestCase
+
+  def setup
+    @path = Dir.mktmpdir
+
+    Redwood::load_constants @path
+
+    $config = load_config Redwood::CONFIG_FN
+    @log_io = File.open(Redwood::LOG_FN, 'a')
+    Redwood::Logger.add_sink @log_io
+    Redwood::HookManager.init Redwood::HOOK_DIR
+    Redwood::SentManager.init $config[:sent_source] || 'sup://sent'
+    Redwood::ContactManager.init Redwood::CONTACT_FN
+    Redwood::LabelManager.init Redwood::LABEL_FN
+    Redwood::AccountManager.init $config[:accounts]
+    Redwood::DraftManager.init Redwood::DRAFT_DIR
+    Redwood::SearchManager.init Redwood::SEARCH_FN
+
+    Redwood::managers.each { |x| x.init unless x.instantiated? }
+
+    Index.init @path
+    Index.load
+    SourceManager.instance.instance_eval '@sources = {}'
+
+    debug "adding draft source.."
+    Redwood::SourceManager.add_source DraftManager.new_source
+  end
+
+  def teardown
+    Redwood::Logger.remove_sink @log_io
+    managers.each { |x| x.deinstantiate! if x.instantiated? }
+
+    @log_io.close if @log_io
+
+    ObjectSpace.each_object(Class).select {|a| a < Redwood::Singleton}.each do |klass|
+      klass.deinstantiate! unless klass == Redwood::Logger
+    end
+
+    warn "removing #{@path}"
+    FileUtils.rm_r @path # this doesn't seem to work properly
+  end
+
+  def test_draft_dir
+    assert (File.directory? File.join(@path, 'drafts'))
+  end
+
+  def do_standard_tests nodelete
+    # try to load message
+    messages_in_index = []
+    Index.instance.each_message {|a| messages_in_index << a}
+    refute_empty messages_in_index, 'There are no messages in the index'
+
+    refute_empty messages_in_index.select { |a| a.is_draft? }, 'There are no drafts in the index.'
+
+    # there should not be more than one item in the index now
+    assert (messages_in_index.count == 1)
+
+    mydraft = messages_in_index[0]
+
+    # load draft
+    header, body = EditMessageMode.parse_file mydraft.draft_filename
+
+    # remove message
+    unless nodelete
+      Index.delete mydraft.id
+
+      messages_in_index = []
+      Index.instance.each_message {|a| messages_in_index << a}
+      assert_empty messages_in_index, 'Index should be empty'
+    end
+  end
+
+  def write_and_load_draft msg, nodelete = false
+    DraftManager.write_draft do |f|
+      f.puts msg
+    end
+
+    do_standard_tests nodelete
+  end
+
+  def write_and_load_headers_body headers, body, msg_id, nodelete = false
+    DraftManager.write_draft do |f|
+
+      f.puts EditMessageMode.format_headers(headers).first
+      f.puts <<EOS
+Date: #{Time.now.rfc2822}
+Message-Id: #{msg_id}
+EOS
+
+      f.puts
+      f.puts EditMessageMode.sanitize_body(body.join("\n"))
+
+    end
+
+    do_standard_tests nodelete
+  end
+
+  def test_write_and_load_draft
+    test_message_1 = <<EOS
+From sup-talk-bounces@rubyforge.org Mon Apr 27 12:56:18 2009
+From: Bob <bob@bob.com>
+To: Joe <joe@joe.com>
+
+Hello there friend. How are you? Blah is blah blah.
+I like mboxes, don't you?
+EOS
+
+    write_and_load_draft test_message_1
+  end
+
+  def test_utf_8_msg
+    utf_8_msg = <<EOS
+From sup-talk-bounces@rubyforge.org Mon Apr 27 12:56:18 2009
+From: Bob <bob@bob.com>
+To: Joe <joe@joe.com>
+
+here's some utf-8: ølååå
+
+Hello there friend. How are you? Blah is blah blah.
+I like mboxes, don't you?
+EOS
+
+    write_and_load_draft utf_8_msg
+
+  end
+
+  def test_utf_8_message_building
+    headers = {"From" => "Bob <bob@bob.com>",
+               "To" => "Joe <joe@joe.com>",
+               "Subject" => "testing øæ",
+    }
+
+    msg_id = "test-draft-101"
+
+    utf_8_msg = <<EOS
+From sup-talk-bounces@rubyforge.org Mon Apr 27 12:56:18 2009
+From: Bob <bob@bob.com>
+To: Joe <joe@joe.com>
+
+here's some utf-8: ølååå
+
+Hello there friend. How are you? Blah is blah blah.
+I like mboxes, don't you?
+EOS
+
+    body_lines = utf_8_msg.split("\n")
+
+    write_and_load_headers_body headers, body_lines, msg_id, false
+  end
+
+  def test_bad_encoding
+    headers = {"From" => "Bob <bob@bob.com>",
+               "To" => "Joe <joe@joe.com>",
+               "Subject" => "testing øæ",
+    }
+
+    msg_id = "test-draft-101"
+
+    utf_8_msg = <<EOS
+From sup-talk-bounces@rubyforge.org Mon Apr 27 12:56:18 2009
+From: Bob <bob@bob.com>
+To: Joe <joe@joe.com>
+
+here's some utf-8: ølååå
+
+Hello there friend. How are you? Blah is blah blah.
+I like mboxes, don't you?
+EOS
+
+    body_lines = utf_8_msg.split("\n").each { |x| x.force_encoding('ASCII') }
+
+    assert_raises ArgumentError do
+      write_and_load_headers_body headers, body_lines, msg_id, false
+    end
+
+  end
+end


### PR DESCRIPTION
This tests adding and removing messages to the draft source, as well as the relevant methods from edit_message_mode.

The tests do not correctly remove all remnants of the files in /tmp.. don't know what is going on there, but if someone wants to have a go please go ahead. Whether it is still a good idea to include the tests like this needs to be reviewed.

Writing and loading draft messages are ensured to be done in utf-8 now, hopefully fixes (and tests) issue #340. Issue #343, still remains, but the tests should hopefully be possible to extend to include this test.

