### PR TITLE
Fail fast if we know we don't have color support

### DIFF
--- a/lib/sup/colormap.rb
+++ b/lib/sup/colormap.rb
@@ -17,6 +17,9 @@ module Ncurses
 
     ## xterm 24-shade grayscale
     24.times { |x| color! "g#{x}", (16+6*6*6) + x }
+  elsif Ncurses::NUM_COLORS == -1
+    ## Terminal emulator doesn't appear to support colors
+    raise ArgumentError, "sup must be run in a terminal with color support"
   end
 end
 


### PR DESCRIPTION
The thought here is to make it clear to the user that either their
terminal or their TERM variable is the problem, rather than providing a
cryptic message about a certain color being 'unknown'.
