### PR TITLE
Improved accuracy of message in thread-index-mode ; "Found" to "Loaded" changed

### DIFF
--- a/lib/sup/modes/thread_index_mode.rb
+++ b/lib/sup/modes/thread_index_mode.rb
@@ -730,7 +730,7 @@ EOS
       opts[:when_done].call(num) if opts[:when_done]
 
       if num > 0
-        BufferManager.flash "Found #{num.pluralize 'thread'}."
+        BufferManager.flash "Loaded #{num.pluralize 'thread'}."
       else
         BufferManager.flash "No matches."
       end


### PR DESCRIPTION
As written there: https://factor.cc/pad/p/sup-ideas (issue 44) using "loaded" instead of "found" is more accurate, because if something isn't found,that doesn't mean it doesn't exist. This improvment has been made as a task on Google Code-In contest: https://www.google-melange.com/gci/task/view/google/gci2014/6127040658931712