### PR TITLE
Fixed issue #254 - auto "fireuping" sup-config, if there are no any configured sources

### DIFF
--- a/bin/sup
+++ b/bin/sup
@@ -158,11 +158,12 @@ begin
   Redwood::start
   Redwood::SourceManager.load_sources
   
-   if Redwood::SourceManager.sources.empty?
+   if Redwood::SourceManager.sources.empty? and !File.exist?("#{Dir.home}/.sup/configured")
     debug "No sources found!"
+    FileUtils.touch("#{Dir.home}/.sup/configured")
     Index.unlock
     exec("sup-config")
-    abort 
+    abort
   end  
 
   Index.load


### PR DESCRIPTION
Added automatic fire-uping "sup-config" if there are no any configured sources.
