### PR TITLE
File::exists? replaced for File::exist?

### DIFF
--- a/bin/sup-sync-back-maildir
+++ b/bin/sup-sync-back-maildir
@@ -60,7 +60,7 @@ $config[:sync_back_to_maildir] = true
 
 begin
   sync_performed = []
-  sync_performed = File.readlines(Redwood::SYNC_OK_FN).collect { |e| e.strip }.find_all { |e| not e.empty? } if File.exists? Redwood::SYNC_OK_FN
+  sync_performed = File.readlines(Redwood::SYNC_OK_FN).collect { |e| e.strip }.find_all { |e| not e.empty? } if File.exist? Redwood::SYNC_OK_FN
   sources = []
 
   ## Try to find out sources given in parameters

--- a/lib/sup.rb
+++ b/lib/sup.rb
@@ -105,7 +105,7 @@ module Redwood
       o
     end
 
-    mode = if File.exists? fn
+    mode = if File.exist? fn
       File.stat(fn).mode
     else
       0600
@@ -113,7 +113,7 @@ module Redwood
 
     if backup
       backup_fn = fn + '.bak'
-      if File.exists?(fn) && File.size(fn) > 0
+      if File.exist?(fn) && File.size(fn) > 0
         File.open(backup_fn, "w", mode) do |f|
           File.open(fn, "r") { |old_f| FileUtils.copy_stream old_f, f }
           f.fsync
@@ -139,7 +139,7 @@ module Redwood
   end
 
   def load_yaml_obj fn, compress=false
-    o = if File.exists? fn
+    o = if File.exist? fn
       if compress
         Zlib::GzipReader.open(fn) { |f| YAML::load f }
       else
@@ -180,7 +180,7 @@ module Redwood
     return if bypass_sync_check
 
     if $config[:sync_back_to_maildir]
-      if not File.exists? Redwood::SYNC_OK_FN
+      if not File.exist? Redwood::SYNC_OK_FN
         Redwood.warn_syncback <<EOS
 It appears that the "sync_back_to_maildir" option has been changed
 from false to true since the last execution of sup.
@@ -191,14 +191,14 @@ Should I complain about this again? (Y/n)
 EOS
         File.open(Redwood::SYNC_OK_FN, 'w') {|f| f.write(Redwood::MAILDIR_SYNC_CHECK_SKIPPED) } if STDIN.gets.chomp.downcase == 'n'
       end
-    elsif not $config[:sync_back_to_maildir] and File.exists? Redwood::SYNC_OK_FN
+    elsif not $config[:sync_back_to_maildir] and File.exist? Redwood::SYNC_OK_FN
       File.delete(Redwood::SYNC_OK_FN)
     end
   end
 
   def check_syncback_settings
     # don't check if syncback was never performed
-    return unless File.exists? Redwood::SYNC_OK_FN
+    return unless File.exist? Redwood::SYNC_OK_FN
     active_sync_sources = File.readlines(Redwood::SYNC_OK_FN).collect { |e| e.strip }.find_all { |e| not e.empty? }
     return if active_sync_sources.length == 1 and active_sync_sources[0] == Redwood::MAILDIR_SYNC_CHECK_SKIPPED
     sources = SourceManager.sources
@@ -338,7 +338,7 @@ EOM
       :continuous_scroll => false,
       :always_edit_async => false,
     }
-    if File.exists? filename
+    if File.exist? filename
       config = Redwood::load_yaml_obj filename
       abort "#{filename} is not a valid configuration file (it's a #{config.class}, not a hash)" unless config.is_a?(Hash)
       default_config.merge config

--- a/lib/sup/colormap.rb
+++ b/lib/sup/colormap.rb
@@ -189,7 +189,7 @@ class Colormap
   ## Try to use the user defined colors, in case of an error fall back
   ## to the default ones.
   def populate_colormap
-    user_colors = if File.exists? Redwood::COLOR_FN
+    user_colors = if File.exist? Redwood::COLOR_FN
       debug "loading user colors from #{Redwood::COLOR_FN}"
       Redwood::load_yaml_obj Redwood::COLOR_FN
     end

--- a/lib/sup/contact.rb
+++ b/lib/sup/contact.rb
@@ -16,7 +16,7 @@ class ContactManager
     @a2p = {} # alias to person
     @e2p = {} # email to person
 
-    if File.exists? fn
+    if File.exist? fn
       IO.foreach(fn) do |l|
         l =~ /^([^:]*): (.*)$/ or raise "can't parse #{fn} line #{l.inspect}"
         aalias, addr = $1, $2

--- a/lib/sup/draft.rb
+++ b/lib/sup/draft.rb
@@ -33,7 +33,7 @@ class DraftLoader < Source
   yaml_properties
 
   def initialize dir=Redwood::DRAFT_DIR
-    Dir.mkdir dir unless File.exists? dir
+    Dir.mkdir dir unless File.exist? dir
     super DraftManager.source_name, true, false
     @dir = dir
     @cur_offset = 0
@@ -62,7 +62,7 @@ class DraftLoader < Source
 
   def gen_offset
     i = 0
-    while File.exists? fn_for_offset(i)
+    while File.exist? fn_for_offset(i)
       i += 1
     end
     i
@@ -75,7 +75,7 @@ class DraftLoader < Source
   end
 
   def load_message offset
-    raise SourceError, "Draft not found" unless File.exists? fn_for_offset(offset)
+    raise SourceError, "Draft not found" unless File.exist? fn_for_offset(offset)
     File.open fn_for_offset(offset) do |f|
       RMail::Mailbox::MBoxReader.new(f).each_message do |input|
         return RMail::Parser.read(input)

--- a/lib/sup/hook.rb
+++ b/lib/sup/hook.rb
@@ -83,7 +83,7 @@ class HookManager
     @contexts = {}
     @tags = {}
 
-    Dir.mkdir dir unless File.exists? dir
+    Dir.mkdir dir unless File.exist? dir
   end
 
   attr_reader :tags

--- a/lib/sup/index.rb
+++ b/lib/sup/index.rb
@@ -105,7 +105,7 @@ EOS
 
   def save
     debug "saving index and sources..."
-    FileUtils.mkdir_p @dir unless File.exists? @dir
+    FileUtils.mkdir_p @dir unless File.exist? @dir
     SourceManager.save_sources
     save_index
   end
@@ -116,7 +116,7 @@ EOS
 
   def load_index failsafe=false
     path = File.join(@dir, 'xapian')
-    if File.exists? path
+    if File.exist? path
       @xapian = Xapian::WritableDatabase.new(path, Xapian::DB_OPEN)
       db_version = @xapian.get_metadata 'version'
       db_version = '0' if db_version.empty?

--- a/lib/sup/label.rb
+++ b/lib/sup/label.rb
@@ -15,7 +15,7 @@ class LabelManager
   def initialize fn
     @fn = fn
     labels =
-      if File.exists? fn
+      if File.exist? fn
         IO.readlines(fn).map { |x| x.chomp.intern }
       else
         []

--- a/lib/sup/maildir.rb
+++ b/lib/sup/maildir.rb
@@ -68,7 +68,7 @@ class Maildir < Source
           File.safe_link tmp_path, new_path
           stored = true
         ensure
-          File.unlink tmp_path if File.exists? tmp_path
+          File.unlink tmp_path if File.exist? tmp_path
         end
       end #rescue Errno...
     end #Dir.chdir
@@ -201,7 +201,7 @@ class Maildir < Source
   def trashed? id; maildir_data(id)[2].include? "T"; end
 
   def valid? id
-    File.exists? File.join(@dir, id)
+    File.exist? File.join(@dir, id)
   end
 
 private

--- a/lib/sup/mbox.rb
+++ b/lib/sup/mbox.rb
@@ -115,7 +115,7 @@ class MBox < Source
   end
 
   def store_message date, from_email, &block
-    need_blank = File.exists?(@path) && !File.zero?(@path)
+    need_blank = File.exist?(@path) && !File.zero?(@path)
     File.open(@path, "ab") do |f|
       f.puts if need_blank
       f.puts "From #{from_email} #{date.asctime}"

--- a/lib/sup/mode.rb
+++ b/lib/sup/mode.rb
@@ -83,7 +83,7 @@ EOS
 ### helper functions
 
   def save_to_file fn, talk=true
-    if File.exists? fn
+    if File.exist? fn
       unless BufferManager.ask_yes_or_no "File \"#{fn}\" exists. Overwrite?"
         info "Not overwriting #{fn}"
         return

--- a/lib/sup/modes/edit_message_mode.rb
+++ b/lib/sup/modes/edit_message_mode.rb
@@ -699,7 +699,7 @@ private
     sigfn = (AccountManager.account_for(from_email) ||
              AccountManager.default_account).signature
 
-    if sigfn && File.exists?(sigfn)
+    if sigfn && File.exist?(sigfn)
       ["", "-- "] + File.readlines(sigfn).map { |l| l.chomp }
     else
       []

--- a/lib/sup/search.rb
+++ b/lib/sup/search.rb
@@ -12,7 +12,7 @@ class SearchManager
   def initialize fn
     @fn = fn
     @searches = {}
-    if File.exists? fn
+    if File.exist? fn
       IO.foreach(fn) do |l|
         l =~ /^([^:]*): (.*)$/ or raise "can't parse #{fn} line #{l.inspect}"
         @searches[$1] = $2

--- a/lib/sup/sent.rb
+++ b/lib/sup/sent.rb
@@ -40,7 +40,7 @@ class SentLoader < MBox
 
   def initialize
     @filename = Redwood::SENT_FN
-    File.open(@filename, "w") { } unless File.exists? @filename
+    File.open(@filename, "w") { } unless File.exist? @filename
     super "mbox://" + @filename, true, $config[:archive_sent]
   end
 

--- a/test/test_message.rb
+++ b/test/test_message.rb
@@ -6,24 +6,6 @@ require 'stringio'
 
 require 'dummy_source'
 
-# override File.exists? to make it work with StringIO for testing.
-# FIXME: do aliasing to avoid breaking this when sup moves from
-# File.exists? to File.exist?
-
-class File
-
-  def File.exists? file
-    # puts "fake File::exists?"
-
-    if file.is_a?(StringIO)
-      return false
-    end
-    # use the different function
-    File.exist?(file)
-  end
-
-end
-
 module Redwood
 
 class TestMessage < ::Minitest::Unit::TestCase

--- a/test/test_messages_dir.rb
+++ b/test/test_messages_dir.rb
@@ -6,24 +6,6 @@ require 'stringio'
 
 require 'dummy_source'
 
-# override File.exists? to make it work with StringIO for testing.
-# FIXME: do aliasing to avoid breaking this when sup moves from
-# File.exists? to File.exist?
-
-class File
-
-  def File.exists? file
-    # puts "fake File::exists?"
-
-    if file.is_a?(StringIO)
-      return false
-    end
-    # use the different function
-    File.exist?(file)
-  end
-
-end
-
 module Redwood
 
 class TestMessagesDir < ::Minitest::Unit::TestCase


### PR DESCRIPTION
As File::exists? is deprecated and gave a lot of warnings when sup was run with the ruby warning flag, these where replaced.

Now just 2 commits in the PR. Hope this is correct. If so, I'll close PR  #389.