### PR TITLE
Filter list-hooks with pattern given with -m option

### DIFF
--- a/bin/sup
+++ b/bin/sup
@@ -39,7 +39,8 @@ Usage:
 
 Options are:
 EOS
-  opt :list_hooks, "List all hooks and descriptions, and quit."
+  opt :list_hooks, "List all hooks and descriptions, and quit. Use --hooks-matching to filter."
+  opt :hooks_matching, "If given, list all hooks and descriptions matching the given pattern. Needs the --list-hooks option", short: "m", default: ""
   opt :no_threads, "Turn off threading. Helps with debugging. (Necessarily disables background polling for new messages.)"
   opt :no_initial_poll, "Don't poll for new messages when starting."
   opt :search, "Search for this query upon startup", :type => String
@@ -65,7 +66,7 @@ EOS
 
 if $opts[:list_hooks]
   Redwood.start
-  Redwood::HookManager.print_hooks
+  Redwood::HookManager.print_hooks $opts[:hooks_matching]
   exit
 end
 

--- a/lib/sup/hook.rb
+++ b/lib/sup/hook.rb
@@ -109,20 +109,20 @@ class HookManager
     @descs[name] = desc
   end
 
-  def print_hooks f=$stdout
-puts <<EOS
-Have #{HookManager.descs.size} registered hooks:
-
-EOS
-
-    HookManager.descs.sort.each do |name, desc|
-      f.puts <<EOS
+  def print_hooks pattern="", f=$stdout
+    matching_hooks = HookManager.descs.sort.keep_if {|name, desc| pattern.empty? or name.match(pattern)}.map do |name, desc|
+      <<EOS
 #{name}
 #{"-" * name.length}
 File: #{fn_for name}
 #{desc}
 EOS
     end
+
+    showing_str = matching_hooks.size == HookManager.descs.size ? "" : " (showing #{matching_hooks.size})"
+    f.puts "Have #{HookManager.descs.size} registered hooks#{showing_str}:"
+    f.puts
+    matching_hooks.each { |text| f.puts text }
   end
 
   def enabled? name; !hook_for(name).nil? end


### PR DESCRIPTION
The matching uses [ruby's match](http://ruby-doc.org/core-2.2.0/String.html#method-i-match) on names only, so it should be pretty flexible.

Example of output:

```
$ sup -l
Have 38 registered hooks:

after-poll
----------
File: /home/rakoo/.sup/hooks/after-poll.rb
Executes immediately after a poll for new messages completes.
Variables:
[...]
```
```
$ sup -l -m before

Have 38 registered hooks (showing 3):

before-add-message
------------------
File: /home/rakoo/.sup/hooks/before-add-message.rb
Executes immediately before a message is added to the index.
Variables:
  message: the new message

before-edit
-----------
File: /home/rakoo/.sup/hooks/before-edit.rb
Modifies message body and headers before editing a new message. Variables
should be modified in place.
Variables:
	header: a hash of headers. See 'signature' hook for documentation.
	body: an array of lines of body text.
Return value:
	none

before-poll
-----------
File: /home/rakoo/.sup/hooks/before-poll.rb
Executes immediately before a poll for new messages commences.
No variables.
```
```
$ sup -l -m edit
async-edit
----------
File: /home/rakoo/.sup/hooks/async-edit.rb
Runs when 'H' is pressed in async edit mode. You can run whatever code
you want here - though the default case would be launching a text
editor. Your hook is assumed to not block, so you should use exec() or
fork() to launch the editor.

Once the hook has returned then sup will be responsive as usual. You will
still need to press 'E' to exit this buffer and send the message.

Variables:
file_path: The full path to the file containing the message to be edited.

Return value: None

before-edit
-----------
File: /home/rakoo/.sup/hooks/before-edit.rb
Modifies message body and headers before editing a new message. Variables
should be modified in place.
Variables:
	header: a hash of headers. See 'signature' hook for documentation.
	body: an array of lines of body text.
Return value:
	none
```

The new help text:

```
$ sup -h
Sup is a curses-based email client.

Usage:
  sup [options]

Options are:
          --list-hooks, -l:   List all hooks and descriptions, and quit. Use
                              --hooks-matching to filter.
  --hooks-matching, -m <s>:   If given, list all hooks and descriptions
                              matching the given pattern. Needs the
                              --list-hooks option (default: )
          --no-threads, -n:   Turn off threading. Helps with debugging.
                              (Necessarily disables background polling for new
                              messages.)
     --no-initial-poll, -o:   Don't poll for new messages when starting.
          --search, -s <s>:   Search for this query upon startup
         --compose, -c <s>:   Compose message to this recipient upon startup
         --subject, -j <s>:   When composing, use this subject
             --version, -v:   Print version and exit
                --help, -h:   Show this message
```

I'll wait for #392 to be merged, then I'll rebase off of the `develop`, but I open this PR now for discussion.