### PR TITLE
Remove include of RR Adapter, as advised

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,3 @@
 require "rubygems" rescue nil
 require 'minitest/autorun'
 require "rr"
-
-class Minitest::Unit::TestCase
-  include ::RR::Adapters::MiniTest
-end


### PR DESCRIPTION
Remove this;
```
--------------------------------------------------------------------------------
RR deprecation warning: RR now has an autohook system. You don't need to
`include RR::Adapters::*` in your test framework's base class anymore.
--------------------------------------------------------------------------------
```