### PR TITLE
Remove pre ruby2.0 code

### DIFF
--- a/lib/sup/crypto.rb
+++ b/lib/sup/crypto.rb
@@ -10,11 +10,11 @@ class CryptoManager
 
   class Error < StandardError; end
 
-  OUTGOING_MESSAGE_OPERATIONS = OrderedHash.new(
-    [:sign, "Sign"],
-    [:sign_and_encrypt, "Sign and encrypt"],
-    [:encrypt, "Encrypt only"]
-  )
+  OUTGOING_MESSAGE_OPERATIONS = {
+    sign: "Sign",
+    sign_and_encrypt: "Sign and encrypt",
+    encrypt: "Encrypt only"
+  }
 
   KEY_PATTERN = /(-----BEGIN PGP PUBLIC KEY BLOCK.*-----END PGP PUBLIC KEY BLOCK)/m
   KEYSERVER_URL = "http://pool.sks-keyservers.net:11371/pks/lookup"
@@ -476,7 +476,7 @@ private
   # elsif only one account,            then leave blank so gpg default will be user
   # else                                    set --local-user from_email_address
   # NOTE: multiple signers doesn't seem to work with gpgme (2.0.2, 1.0.8)
-  #       
+  #
   def gen_sign_user_opts from
     account = AccountManager.account_for from
     account ||= AccountManager.default_account

--- a/lib/sup/mode.rb
+++ b/lib/sup/mode.rb
@@ -46,7 +46,7 @@ class Mode
   end
 
   def resolve_input c
-    ancestors.each do |klass| # try all keymaps in order of ancestry
+    self.class.ancestors.each do |klass| # try all keymaps in order of ancestry
       next unless @@keymaps.member?(klass)
       action = BufferManager.resolve_input_with_keymap c, @@keymaps[klass]
       return action if action
@@ -62,7 +62,7 @@ class Mode
 
   def help_text
     used_keys = {}
-    ancestors.map do |klass|
+    self.class.ancestors.map do |klass|
       km = @@keymaps[klass] or next
       title = "Keybindings from #{Mode.make_name klass.name}"
       s = <<EOS

--- a/lib/sup/modes/thread_view_mode.rb
+++ b/lib/sup/modes/thread_view_mode.rb
@@ -940,9 +940,10 @@ private
         addressee_lines += format_person_list "   Bcc: ", m.bcc
       end
 
-      headers = OrderedHash.new
-      headers["Date"] = "#{m.date.to_message_nice_s} (#{m.date.to_nice_distance_s})"
-      headers["Subject"] = m.subj
+      headers = {
+        "Date" => "#{m.date.to_message_nice_s} (#{m.date.to_nice_distance_s})",
+        "Subject" => m.subj
+      }
 
       show_labels = @thread.labels - LabelManager::HIDDEN_RESERVED_LABELS
       unless show_labels.empty?

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -182,17 +182,6 @@ class Module
 end
 
 class Object
-  def ancestors
-    ret = []
-    klass = self.class
-
-    until klass == Object
-      ret << klass
-      klass = klass.superclass
-    end
-    ret
-  end
-
   ## "k combinator"
   def returning x; yield x; x; end
 

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -491,12 +491,6 @@ class Fixnum
     end
   end
 
-  unless method_defined?(:ord)
-    def ord
-      self
-    end
-  end
-
   ## hacking the english language
   def pluralize s
     to_s + " " +

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -574,10 +574,6 @@ module Enumerable
   end
 end
 
-unless Object.const_defined? :Enumerator
-  Enumerator = Enumerable::Enumerator
-end
-
 class Array
   def flatten_one_level
     inject([]) { |a, e| a + e }

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -366,8 +366,6 @@ class String
 
   # Fix the damn string! make sure it is valid utf-8, then convert to
   # user encoding.
-  #
-  # Not Ruby 1.8 compatible
   def fix_encoding!
     # first try to encode to utf-8 from whatever current encoding
     encode!('UTF-8', :invalid => :replace, :undef => :replace)
@@ -390,8 +388,6 @@ class String
 
   # transcode the string if original encoding is know
   # fix if broken.
-  #
-  # Not Ruby 1.8 compatible
   def transcode to_encoding, from_encoding
     begin
       encode!(to_encoding, from_encoding, :invalid => :replace, :undef => :replace)

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -161,13 +161,6 @@ module RMail
   end
 end
 
-class Range
-  ## only valid for integer ranges (unless I guess it's exclusive)
-  def size
-    last - first + (exclude_end? ? 0 : 1)
-  end
-end
-
 class Module
   def bool_reader *args
     args.each { |sym| class_eval %{ def #{sym}?; @#{sym}; end } }

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -669,32 +669,6 @@ class SavingHash
   defer_all_other_method_calls_to :hash
 end
 
-class OrderedHash < Hash
-  alias_method :store, :[]=
-  alias_method :each_pair, :each
-  attr_reader :keys
-
-  def initialize *a
-    @keys = []
-    a.each { |k, v| self[k] = v }
-  end
-
-  def []= key, val
-    @keys << key unless member?(key)
-    super
-  end
-
-  def values; keys.map { |k| self[k] } end
-  def index key; @keys.index key end
-
-  def delete key
-    @keys.delete key
-    super
-  end
-
-  def each; @keys.each { |k| yield k, self[k] } end
-end
-
 ## easy thread-safe class for determining who's the "winner" in a race (i.e.
 ## first person to hit the finish line
 class FinishLine

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -10,15 +10,6 @@ require 'benchmark'
 require 'unicode'
 require 'fileutils'
 
-## time for some monkeypatching!
-class Symbol
-  unless method_defined? :to_proc
-    def to_proc
-      proc {  |obj, *args| obj.send(self, *args) }
-    end
-  end
-end
-
 class Lockfile
   def gen_lock_id
     Hash[

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -454,13 +454,6 @@ class String
     out = out.fix_encoding! # this should now be an utf-8 string of ascii
                            # compat chars.
   end
-
-  unless method_defined? :ascii_only?
-    def ascii_only?
-      size.times { |i| return false if self[i] & 128 != 0 }
-      return true
-    end
-  end
 end
 
 class Numeric


### PR DESCRIPTION
Was going through util.rb when going through the `use-mail` branch and found a couple of line which were unneeded as the supported versions of ruby are all 2.0 and up.