### PR TITLE
Handle content-type-headers with spaces around parameter equal-sign

### DIFF
--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -80,7 +80,7 @@ module RMail
     end
 
     def charset
-      if header.field?("content-type") && header.fetch("content-type") =~ /charset="?(.*?)"?(;|$)/i
+      if header.field?("content-type") && header.fetch("content-type") =~ /charset\s*=\s*"?(.*?)"?(;|$)/i
         $1
       end
     end


### PR DESCRIPTION
For fixing bug 418