### PR TITLE
Removed all 'require 'rubygems*' lines, these are autoloaded

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'rake/testtask'
 require "bundler/gem_tasks"
 

--- a/bin/sup
+++ b/bin/sup
@@ -3,7 +3,6 @@
 
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
-require 'rubygems'
 require 'ncursesw'
 
 require 'sup/util/ncurses'

--- a/bin/sup-add
+++ b/bin/sup-add
@@ -3,7 +3,6 @@
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
 require 'uri'
-require 'rubygems'
 require 'highline/import'
 require 'trollop'
 require "sup"

--- a/bin/sup-config
+++ b/bin/sup-config
@@ -2,7 +2,6 @@
 
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
-require 'rubygems'
 require 'highline/import'
 require 'trollop'
 require "sup"

--- a/bin/sup-dump
+++ b/bin/sup-dump
@@ -2,7 +2,6 @@
 
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
-require 'rubygems'
 require 'xapian'
 require 'trollop'
 require 'set'

--- a/bin/sup-import-dump
+++ b/bin/sup-import-dump
@@ -3,7 +3,6 @@
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
 require 'uri'
-require 'rubygems'
 require 'trollop'
 require "sup"
 

--- a/bin/sup-sync
+++ b/bin/sup-sync
@@ -3,7 +3,6 @@
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
 require 'uri'
-require 'rubygems'
 require 'trollop'
 require "sup"
 

--- a/bin/sup-sync-back-maildir
+++ b/bin/sup-sync-back-maildir
@@ -3,7 +3,6 @@
 
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
-require 'rubygems'
 require 'trollop'
 require "sup"
 

--- a/bin/sup-tweak-labels
+++ b/bin/sup-tweak-labels
@@ -2,7 +2,6 @@
 
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
-require 'rubygems'
 require 'trollop'
 require "sup"
 

--- a/contrib/colorpicker.rb
+++ b/contrib/colorpicker.rb
@@ -1,5 +1,3 @@
-require 'rubygems'
-
 require 'ncursesw'
 
 Ncurses.initscr

--- a/devel/profile.rb
+++ b/devel/profile.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'ruby-prof'
 require "redwood"
 

--- a/ext/mkrf_conf_xapian.rb
+++ b/ext/mkrf_conf_xapian.rb
@@ -1,6 +1,3 @@
-require 'rubygems'
-require 'rubygems/command.rb'
-require 'rubygems/dependency_installer.rb'
 require 'rbconfig'
 
 begin

--- a/lib/sup.rb
+++ b/lib/sup.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-require 'rubygems'
 require 'yaml'
 require 'zlib'
 require 'thread'


### PR DESCRIPTION
Ninja edit: As ruby <= 2.0 is not supported and rubygems is autoloaded since 1.9.