### PR TITLE
call update_message_state with correct arguments

### DIFF
--- a/bin/sup-import-dump
+++ b/bin/sup-import-dump
@@ -82,7 +82,7 @@ begin
     next if opts[:dry_run]
 
     m.labels = new_labels
-    index.update_message_state m
+    index.update_message_state [m, false]
   end
 
   index.commit_transaction if opts[:atomic]


### PR DESCRIPTION
In sup-import-dump:
we need to hand a list to index.update_message_state, otherwise we'll get an exception.

This causes all imports using sup-import-dump to fail currently.