### PR TITLE
Handle spaces in RFC2047 headers

### DIFF
--- a/lib/sup/rfc2047.rb
+++ b/lib/sup/rfc2047.rb
@@ -17,7 +17,7 @@
 # This file is distributed under the same terms as Ruby.
 
 module Rfc2047
-  WORD = %r{=\?([!\#$%&'*+-/0-9A-Z\\^\`a-z{|}~]+)\?([BbQq])\?([!->@-~]+)\?=} # :nodoc: 'stupid ruby-mode
+  WORD = %r{=\?([!\#$%&'*+-/0-9A-Z\\^\`a-z{|}~]+)\?([BbQq])\?([!->@-~ ]+)\?=} # :nodoc: 'stupid ruby-mode
   WORDSEQ = %r{(#{WORD.source})\s+(?=#{WORD.source})}
 
   def Rfc2047.is_encoded? s; s =~ WORD end

--- a/test/fixtures/rfc_2047_subject_with_spaces.eml
+++ b/test/fixtures/rfc_2047_subject_with_spaces.eml
@@ -1,0 +1,6 @@
+From: foo@aol.com
+To: foo@test.com
+Subject: =?ISO-8859-1?Q?Some text that contains encoded chars =E4=E5=E6, spaces ?=
+    =?ISO-8859-1?Q?and_some-text-without-spaces?=
+
+test message

--- a/test/test_message.rb
+++ b/test/test_message.rb
@@ -220,11 +220,28 @@ class TestMessage < Minitest::Test
     fn = chunks[3].safe_filename
     assert_equal(fn, File.basename(fn))
   end
+
+  def test_rfc_2047_subject_with_spaces
+    message = fixture('rfc_2047_subject_with_spaces.eml')
+
+    source = DummySource.new("sup-test://test_rfc_2047_subject_with_spaces")
+    source.messages = [ message ]
+    source_info = 0
+
+    sup_message = Message.build_from_source(source, source_info)
+    sup_message.load_from_source!
+
+    # read the message body chunks
+    sup_message.load_from_source!
+
+    # check that subject was properly decoded
+    assert_equal("Some text that contains encoded chars äåæ, spaces and some-text-without-spaces", sup_message.subj)
+  end
+
   # TODO: test different error cases, malformed messages etc.
 
   # TODO: test different quoting styles, see that they are all divided
   # to chunks properly
-
 end
 
 end


### PR DESCRIPTION
Adds test, and patches it in our RFC2047-decoder