### PR TITLE
Do not create drafts IDs that will not be polled

### DIFF
--- a/lib/sup/draft.rb
+++ b/lib/sup/draft.rb
@@ -61,7 +61,7 @@ class DraftLoader < Source
   end
 
   def gen_offset
-    i = 0
+    i = @cur_offset
     while File.exist? fn_for_offset(i)
       i += 1
     end


### PR DESCRIPTION
Polling DraftLoader will only add messages that have an ID larger than
any previous polled messages, so instead of reusing the ID-space only
create IDs that are larger than any previous added ID.

Reusing the ID-space causes a race-condition where a new draft can be
given an ID that was used by some discarded draft, so that polling
DraftLoader will ignore the newly created draft because it thinks that
this message have already been loaded.

It should be noted that DraftLoader is lazily initialized, so creating
draft IDs will reuse the ID-space as long as these messages has not yet
been polled, but this is not problematic because this part of the
ID-space will be added during the next poll.

Signed-off-by: Johannes Larsen <mail@johslarsen.net>