### PR TITLE
Optimize text wrapping

### DIFF
--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -253,7 +253,8 @@ class String
   def slice_by_display_length len
     each_char.each_with_object "" do |c, buffer|
       len -= c.display_length
-      buffer << c if len >= 0
+      return buffer if len < 0
+      buffer << c
     end
   end
 

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -252,7 +252,9 @@ class String
 
   def slice_by_display_length len
     each_char.each_with_object "" do |c, buffer|
-      len -= c.display_length
+      width = Unicode.width(c, false)
+      width = 1 if width < 0
+      len -= width
       return buffer if len < 0
       buffer << c
     end

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -344,13 +344,14 @@ class String
     ret = []
     s = self
     while s.display_length > len
-      cut = s.slice_by_display_length(len).rindex(/\s/)
+      slice = s.slice_by_display_length(len)
+      cut = slice.rindex(/\s/)
       if cut
         ret << s[0 ... cut]
         s = s[(cut + 1) .. -1]
       else
-        ret << s.slice_by_display_length(len)
-        s = s[ret.last.length .. -1]
+        ret << slice
+        s = s[slice.length .. -1]
       end
     end
     ret << s


### PR DESCRIPTION
Today I got a message with a line that was almost 20kb long. It turned out sup doesn't deal with lines this long very well - it took almost 2 minutes to open the message on a poor old mail box of mine.

Few simple tweaks to the String.wrap and String.slice_by_display_length make text wrapping much, much faster, and wrap now finishes in less than a second.

Here is the script I used for benchmarking: https://gist.github.com/vickenty/202e55db75106b338277