### PR TITLE
Use standard unit abbreviations and prefixes for attachment size

### DIFF
--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -464,13 +464,13 @@ class Numeric
 
   def to_human_size
     if self < 1024
-      to_s + "b"
+      to_s + "B"
     elsif self < (1024 * 1024)
-      (self / 1024).to_s + "k"
+      (self / 1024).to_s + "KiB"
     elsif self < (1024 * 1024 * 1024)
-      (self / 1024 / 1024).to_s + "m"
+      (self / 1024 / 1024).to_s + "MiB"
     else
-      (self / 1024 / 1024 / 1024).to_s + "g"
+      (self / 1024 / 1024 / 1024).to_s + "GiB"
     end
   end
 end


### PR DESCRIPTION
'k', 'm', et cetera are probably clear enough for most users to
interpret, but not all (personally, I keep getting caught by 'b' when
I'm sleep-deprived - that should be 'bits', but I know what the authors
mean is 'bytes'/'B').