### PR TITLE
INDENT_SPACES are now configurable via config.yaml

### DIFF
--- a/lib/sup.rb
+++ b/lib/sup.rb
@@ -331,6 +331,7 @@ EOM
       :poll_interval => 300,
       :wrap_width => 0,
       :slip_rows => 0,
+      :indent_spaces => 2,
       :col_jump => 2,
       :stem_language => "english",
       :sync_back_to_maildir => false,

--- a/lib/sup/modes/thread_view_mode.rb
+++ b/lib/sup/modes/thread_view_mode.rb
@@ -10,8 +10,6 @@ class ThreadViewMode < LineCursorMode
     attr_accessor :state
   end
 
-  INDENT_SPACES = 2 # how many spaces to indent child messages
-
   HookManager.register "detailed-headers", <<EOS
 Add or remove headers from the detailed header display of a message.
 Variables:
@@ -127,6 +125,7 @@ EOS
   ## objects. @person_lines is a map from row #s to Person objects.
 
   def initialize thread, hidden_labels=[], index_mode=nil
+    @indent_spaces = $config[:indent_spaces]
     super :slip_rows => $config[:slip_rows]
     @thread = thread
     @hidden_labels = hidden_labels
@@ -561,7 +560,7 @@ EOS
     l = @layout[m]
 
     ## boundaries of the message
-    message_left = l.depth * INDENT_SPACES
+    message_left = l.depth * @indent_spaces
     message_right = message_left + l.width
 
     ## calculate leftmost colum
@@ -886,7 +885,7 @@ private
           (0 ... text.length).each do |i|
             @chunk_lines[@text.length + i] = c
             @message_lines[@text.length + i] = m
-            lw = text[i].flatten.select { |x| x.is_a? String }.map { |x| x.display_length }.sum - (depth * INDENT_SPACES)
+            lw = text[i].flatten.select { |x| x.is_a? String }.map { |x| x.display_length }.sum - (depth * @indent_spaces)
             l.width = lw if lw > l.width
           end
           @text += text
@@ -991,7 +990,7 @@ private
 
   ## todo: check arguments on this overly complex function
   def chunk_to_lines chunk, state, start, depth, parent=nil, color=nil, star_color=nil
-    prefix = " " * INDENT_SPACES * depth
+    prefix = " " * @indent_spaces * depth
     case chunk
     when :fake_root
       [[[:missing_message_color, "#{prefix}<one or more unreceived messages>"]]]


### PR DESCRIPTION
Messages in thread view can be configured to be inset more or less. The default remains the previous setting - 2 spaces.