### PR TITLE
@ in thread-view-mode should update the thread for new messages

### DIFF
--- a/lib/sup/modes/thread_view_mode.rb
+++ b/lib/sup/modes/thread_view_mode.rb
@@ -52,6 +52,7 @@ EOS
     k.add :toggle_detailed_header, "Toggle detailed header", 'h'
     k.add :show_header, "Show full message header", 'H'
     k.add :show_message, "Show full message (raw form)", 'V'
+    k.add :reload, "Update message in thread", '@'
     k.add :activate_chunk, "Expand/collapse or activate item", :enter
     k.add :expand_all_messages, "Expand/collapse all messages", 'E'
     k.add :edit_draft, "Edit draft", 'e'
@@ -203,6 +204,11 @@ EOS
     m = @message_lines[curpos] or return
     @layout[m].state = (@layout[m].state == :detailed ? :open : :detailed)
     update
+  end
+  
+  def reload
+    regen_text
+    buffer.mark_dirty if buffer
   end
 
   def reply type_arg=nil

--- a/lib/sup/modes/thread_view_mode.rb
+++ b/lib/sup/modes/thread_view_mode.rb
@@ -207,8 +207,7 @@ EOS
   end
   
   def reload
-    regen_text
-    buffer.mark_dirty if buffer
+    update
   end
 
   def reply type_arg=nil


### PR DESCRIPTION
Regenerate messages in thread-view-model when '@' hotkey clicked by calling update function that update text and marking buffer dirty.

GCI task: https://codein.withgoogle.com/dashboard/task-instances/5633471321997312/