### PR TITLE
Add support for storing sent mails per account.

### DIFF
--- a/bin/sup
+++ b/bin/sup
@@ -162,12 +162,6 @@ begin
     Redwood::SourceManager.add_source DraftManager.new_source
   end
 
-  if(s = Redwood::SourceManager.source_for SentManager.source_uri)
-    SentManager.source = s
-  else
-    Redwood::SourceManager.add_source SentManager.default_source
-  end
-
   HookManager.run "startup"
   Redwood::Keymap.run_hook global_keymap
 

--- a/bin/sup-config
+++ b/bin/sup-config
@@ -106,7 +106,6 @@ end
 @cli.wrap_at = :auto
 Redwood::start
 index = Redwood::Index.init
-Redwood::SourceManager.load_sources
 
 @cli.say <<EOS
 Howdy neighbor! This here's sup-config, ready to help you jack in to
@@ -162,7 +161,7 @@ until done
   end
 end
 
-@cli.say "\nSup needs to know where to store your sent messages."
+@cli.say "\nSup needs to know where to store your sent messages by default."
 @cli.say "Only sources capable of storing mail will be listed.\n\n"
 
 Redwood::SourceManager.load_sources
@@ -170,19 +169,19 @@ if Redwood::SourceManager.sources.empty?
   @cli.say "\nUsing the default sup://sent, since you haven't configured other sources yet."
   $config[:sent_source] = 'sup://sent'
 else
-  # this handles the event that source.yaml already contains the SentLoader
+  # this handles the event that source.yaml already contains the SentSource
   # source.
   have_sup_sent = false
 
   @cli.choose do |menu|
     menu.prompt = "Store my sent mail in? "
 
-    menu.choice('Default (an mbox in ~/.sup, aka sup://sent)') { $config[:sent_source] = 'sup://sent'} unless have_sup_sent
-
     valid_sents = Redwood::SourceManager.sources.each do |s|
       have_sup_sent = true if s.to_s.eql?('sup://sent')
       menu.choice(s.to_s) { $config[:sent_source] = s.to_s } if s.respond_to? :store_message
     end
+
+    menu.choice('Default (an mbox in ~/.sup, aka sup://sent)') { $config[:sent_source] = 'sup://sent' } unless have_sup_sent
   end
 end
 

--- a/bin/sup-sync
+++ b/bin/sup-sync
@@ -100,12 +100,6 @@ index.lock_interactively or exit
 begin
   index.load
 
-  if(s = Redwood::SourceManager.source_for Redwood::SentManager.source_uri)
-    Redwood::SentManager.source = s
-  else
-    Redwood::SourceManager.add_source Redwood::SentManager.default_source
-  end
-
   sources = if opts[:all_sources]
     Redwood::SourceManager.sources
   elsif ARGV.empty?

--- a/lib/sup.rb
+++ b/lib/sup.rb
@@ -154,7 +154,7 @@ module Redwood
   end
 
   def managers
-    %w(HookManager SentManager ContactManager LabelManager AccountManager
+    %w(HookManager ContactManager LabelManager AccountManager
     DraftManager UpdateManager PollManager CryptoManager UndoManager
     SourceManager SearchManager IdleManager).map { |x| Redwood.const_get x.to_sym }
   end
@@ -167,7 +167,9 @@ module Redwood
     @log_io = File.open(Redwood::LOG_FN, 'a')
     Redwood::Logger.add_sink @log_io
     Redwood::HookManager.init Redwood::HOOK_DIR
-    Redwood::SentManager.init $config[:sent_source] || 'sup://sent'
+    Redwood::SourceManager.init
+    Redwood::SourceManager.load_sources
+    Redwood::SourceManager.sanitize_sources
     Redwood::ContactManager.init Redwood::CONTACT_FN
     Redwood::LabelManager.init Redwood::LABEL_FN
     Redwood::AccountManager.init $config[:accounts]
@@ -327,7 +329,6 @@ EOM
       :load_more_threads_when_scrolling => true,
       :default_attachment_save_dir => "",
       :sent_source => "sup://sent",
-      :archive_sent => true,
       :poll_interval => 300,
       :wrap_width => 0,
       :slip_rows => 0,

--- a/lib/sup/index.rb
+++ b/lib/sup/index.rb
@@ -99,7 +99,6 @@ EOS
   end
 
   def load failsafe=false
-    SourceManager.load_sources
     load_index failsafe
   end
 

--- a/lib/sup/mbox.rb
+++ b/lib/sup/mbox.rb
@@ -14,7 +14,7 @@ class MBox < Source
   ## uri_or_fp is horrific. need to refactor.
   def initialize uri_or_fp, usual=true, archived=false, id=nil, labels=nil
     @mutex = Mutex.new
-    @labels = Set.new((labels || []) - LabelManager::RESERVED_LABELS)
+    @labels = Set.new(labels || [])
 
     case uri_or_fp
     when String
@@ -115,11 +115,13 @@ class MBox < Source
   end
 
   def store_message date, from_email, &block
-    need_blank = File.exist?(@path) && !File.zero?(@path)
-    File.open(@path, "ab") do |f|
-      f.puts if need_blank
-      f.puts "From #{from_email} #{date.asctime}"
-      yield f
+    @mutex.synchronize do
+      need_blank = File.exist?(@path) && !File.zero?(@path)
+      File.open(@path, "ab") do |f|
+        f.puts if need_blank
+        f.puts "From #{from_email} #{date.asctime}"
+        yield f
+      end
     end
   end
 

--- a/lib/sup/sent.rb
+++ b/lib/sup/sent.rb
@@ -1,47 +1,13 @@
 module Redwood
 
-class SentManager
-  include Redwood::Singleton
+class SentSource < MBox
+  include SerializeLabelsNicely
+  yaml_properties :archived, :id, :labels
 
-  attr_reader :source, :source_uri
-
-  def initialize source_uri
-    @source = nil
-    @source_uri = source_uri
-  end
-
-  def source_id; @source.id; end
-
-  def source= s
-    raise FatalSourceError.new("Configured sent_source [#{s.uri}] can't store mail.  Correct your configuration.") unless s.respond_to? :store_message
-    @source_uri = s.uri
-    @source = s
-  end
-
-  def default_source
-    @source = SentLoader.new
-    @source_uri = @source.uri
-    @source
-  end
-
-  def write_sent_message date, from_email, &block
-    ::Thread.new do
-      debug "store the sent message (locking sent source..)"
-      @source.synchronize do
-        @source.store_message date, from_email, &block
-      end
-      PollManager.poll_from @source
-    end
-  end
-end
-
-class SentLoader < MBox
-  yaml_properties
-
-  def initialize
+  def initialize archived=nil, id=nil, labels=nil
     @filename = Redwood::SENT_FN
     File.open(@filename, "w") { } unless File.exist? @filename
-    super "mbox://" + @filename, true, $config[:archive_sent]
+    super "mbox://" + @filename, true, archived, id, labels
   end
 
   def file_path; @filename end
@@ -49,8 +15,8 @@ class SentLoader < MBox
   def to_s; 'sup://sent'; end
   def uri; 'sup://sent' end
 
-  def id; 9998; end
-  def labels; [:inbox, :sent]; end
+  def is_source_for? uri; super || uri == 'sup://sent'; end
+
   def default_labels; []; end
   def read?; true; end
 end


### PR DESCRIPTION
 • Remain backwards compatible by adding a source with id 9998
   to the sup://sent standard mbox
 • Add new YAML keyword :sent_source: to accounts
 • Code cleanups due to the new handling of sent sources

Should fix #255 and #395.
