### PR TITLE
Add support for zipped maildirs

### DIFF
--- a/bin/sup-add
+++ b/bin/sup-add
@@ -100,6 +100,8 @@ begin
       case parsed_uri.scheme
       when "maildir"
         Redwood::Maildir.new uri, !$opts[:unusual], $opts[:archive], $opts[:sync_back], nil, labels
+      when "maildir+zip"
+        Redwood::ZippedMaildir.new uri, !$opts[:unusual], $opts[:archive], $opts[:sync_back], nil, labels
       when "mbox"
         Redwood::MBox.new uri, !$opts[:unusual], $opts[:archive], nil, labels
       when nil

--- a/bin/sup-config
+++ b/bin/sup-config
@@ -33,6 +33,7 @@ def add_source
     menu.prompt = "What type of mail source is it? "
     menu.choice("mbox file") { type = :mbox }
     menu.choice("maildir directory") { type = :maildir }
+    menu.choice("maildir directory in a zip file") { type = :zipped_maildir }
     menu.choice("Get me out of here!") { return }
   end
 
@@ -56,6 +57,14 @@ def add_source
       $last_fn = fn
       [Redwood::Maildir.suggest_labels_for(fn),
        { :scheme => "maildir", :path => fn }]
+    when :zipped_maildir
+      $last_fn ||= ENV["MAIL"]
+      fn = axe "What's the full path to the maildir zip file?", $last_fn
+      return if fn.nil? || fn.empty?
+
+      $last_fn = fn
+      [Redwood::ZippedMaildir.suggest_labels_for(fn),
+       { :scheme => "maildir+zip", :path => fn }]
     end
 
     uri = begin

--- a/lib/sup/source.rb
+++ b/lib/sup/source.rb
@@ -37,6 +37,7 @@ class Source
   ## - load_message offset
   ## - raw_header offset
   ## - raw_message offset
+  ## - each_raw_message_line
   ## - store_message (optional)
   ## - poll (loads new messages)
   ## - go_idle (optional)

--- a/sup.gemspec
+++ b/sup.gemspec
@@ -59,6 +59,7 @@ SUP: please note that our old mailing lists have been shut down,
   s.add_runtime_dependency "locale", "~> 2.0"
   s.add_runtime_dependency "chronic", "~> 0.9.1"
   s.add_runtime_dependency "unicode", "~> 0.4.4"
+  s.add_runtime_dependency "rubyzip", ">= 1.0.0"
 
   s.add_development_dependency "bundler", "~> 1.3"
   s.add_development_dependency "rake"


### PR DESCRIPTION
This pull request adds support for maildirs stored in zip files.

The huge number of files in my maildir slows down my backups
tremendously. Therefore, I want to create yearly archives (single
files) of my emails -- but still have them in my mail client.
And I want the conversion to be fully reversible.

The alternative would be to convert the emails to mbox files.
There is http://archivemail.sf.net/ which hasn't been updated
in years, but seems to still work. However, I'm not confident
that the conversion will be correct (there are multiple mbox
variants and intricacies around escaping) and can safely be
reversed.

Why zip, why not tar+gzip? Because zip allows random access
whereas tar+gzip only allows sequential access. 
There are a few downsides:

1. It adds a dependency on rubyzip.

2. Writeback isn't supported. It could be added.
   But it's not necessary for the intended use case.

3. Apparently, no other mailclient supports it.

4. The downside of zip is that a bit error at the wrong location
   (within the central directory of the zip file) can corrupt
   the entire zip file.

The implementation is straightforward. It adds a `BaseMaildir`
class of which `Maildir` and `ZippedMaildir` inherit and which
holds the common methods. There is relatively little code that
is actually new, but see `ZippedMaildir` for the new code.

I'm not happy with the method name `do_poll` (called by `poll`,
it's the first section of poll and contains the parts of `poll`
that are different in `Maildir` and `ZippedMaildir`), but
couldn't find a better name.