### PR TITLE
gemspec: Support chronic version 0.10

### DIFF
--- a/sup.gemspec
+++ b/sup.gemspec
@@ -57,7 +57,7 @@ SUP: please note that our old mailing lists have been shut down,
   s.add_runtime_dependency "lockfile"
   s.add_runtime_dependency "mime-types", "> 2.0"
   s.add_runtime_dependency "locale", "~> 2.0"
-  s.add_runtime_dependency "chronic", "~> 0.9.1"
+  s.add_runtime_dependency "chronic", [">= 0.9.1", "~> 0.10.0"]
   s.add_runtime_dependency "unicode", "~> 0.4.4"
 
   s.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Support chronic version 0.10.x.

In Debian, chronic version bumped up 0.10, and those versions are compatible with sup.