### PR TITLE
accept and discard 'uplevel' argument in logging methods

### DIFF
--- a/lib/sup/logger.rb
+++ b/lib/sup/logger.rb
@@ -71,7 +71,7 @@ end
 
 ## include me to have top-level #debug, #info, etc. methods.
 module LogsStuff
-  Logger::LEVELS.each { |l| define_method(l) { |s| Logger.instance.send(l, s) } }
+  Logger::LEVELS.each { |l| define_method(l) { |s, uplevel = 0| Logger.instance.send(l, s) } }
 end
 
 end


### PR DESCRIPTION
We will need this for Ruby 2.7 but it should be fine on older versions too.