### PR TITLE
replace trollop with optimist

### DIFF
--- a/bin/sup
+++ b/bin/sup
@@ -17,7 +17,7 @@ rescue LoadError
 end
 
 require 'fileutils'
-require 'trollop'
+require 'optimist'
 require "sup"
 
 if ENV['SUP_PROFILE']
@@ -29,7 +29,7 @@ if no_gpgme
   info "No 'gpgme' gem detected. Install it for email encryption, decryption and signatures."
 end
 
-$opts = Trollop::options do
+$opts = Optimist::options do
   version "sup v#{Redwood::VERSION}"
   banner <<EOS
 Sup is a curses-based email client.
@@ -48,7 +48,7 @@ EOS
   opt :subject, "When composing, use this subject", :type => String, :short => "j"
 end
 
-Trollop::die :subject, "requires --compose" if $opts[:subject] && !$opts[:compose]
+Optimist::die :subject, "requires --compose" if $opts[:subject] && !$opts[:compose]
 
 Redwood::HookManager.register "startup", <<EOS
 Executes at startup

--- a/bin/sup-add
+++ b/bin/sup-add
@@ -3,11 +3,11 @@
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
 require 'uri'
-require 'trollop'
+require 'optimist'
 require "sup"
 require 'sup/util/axe'
 
-$opts = Trollop::options do
+$opts = Optimist::options do
   version "sup-add (sup #{Redwood::VERSION})"
   banner <<EOS
 Adds a source to the Sup source list.
@@ -35,7 +35,7 @@ EOS
   opt :force_account, "Reuse previously defined account user@hostname.", :type => String
 end
 
-Trollop::die "require one or more sources" if ARGV.empty?
+Optimist::die "require one or more sources" if ARGV.empty?
 
 ## for sources that require login information, prompt the user for
 ## that. also provide a list of previously-defined login info to
@@ -103,9 +103,9 @@ begin
       when "mbox"
         Redwood::MBox.new uri, !$opts[:unusual], $opts[:archive], nil, labels
       when nil
-        Trollop::die "Sources must be specified with an URI"
+        Optimist::die "Sources must be specified with an URI"
       else
-        Trollop::die "Unknown source type #{parsed_uri.scheme.inspect}"
+        Optimist::die "Unknown source type #{parsed_uri.scheme.inspect}"
       end
     @cli.say "Adding #{source}..."
     Redwood::SourceManager.add_source source

--- a/bin/sup-config
+++ b/bin/sup-config
@@ -2,11 +2,11 @@
 
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
-require 'trollop'
+require 'optimist'
 require "sup"
 require 'sup/util/axe'
 
-$opts = Trollop::options do
+$opts = Optimist::options do
   version "sup-config (sup #{Redwood::VERSION})"
   banner <<EOS
 Interactive configuration tool for Sup. Won't destroy existing

--- a/bin/sup-dump
+++ b/bin/sup-dump
@@ -3,12 +3,12 @@
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
 require 'xapian'
-require 'trollop'
+require 'optimist'
 require 'set'
 
 BASE_DIR = ENV["SUP_BASE"] || File.join(ENV["HOME"], ".sup")
 
-$opts = Trollop::options do
+$opts = Optimist::options do
   version "sup-dump"
   banner <<EOS
 Dumps all message state from the sup index to standard out. You can

--- a/bin/sup-import-dump
+++ b/bin/sup-import-dump
@@ -3,7 +3,7 @@
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
 require 'uri'
-require 'trollop'
+require 'optimist'
 require "sup"
 
 PROGRESS_UPDATE_INTERVAL = 15 # seconds
@@ -11,7 +11,7 @@ PROGRESS_UPDATE_INTERVAL = 15 # seconds
 class AbortExecution < SystemExit
 end
 
-opts = Trollop::options do
+opts = Optimist::options do
   version "sup-import-dump (sup #{Redwood::VERSION})"
   banner <<EOS
 Imports message state previously exported by sup-dump into the index.
@@ -36,8 +36,8 @@ EOS
 
   conflicts :ignore_missing, :warn_missing, :abort_missing
 end
-Trollop::die "No dump file given" if ARGV.empty?
-Trollop::die "Extra arguments given" if ARGV.length > 1
+Optimist::die "No dump file given" if ARGV.empty?
+Optimist::die "Extra arguments given" if ARGV.length > 1
 dump_name = ARGV.shift
 missing_action = [:ignore_missing, :warn_missing, :abort_missing].find { |x| opts[x] } || :abort_missing
 

--- a/bin/sup-sync
+++ b/bin/sup-sync
@@ -3,7 +3,7 @@
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
 require 'uri'
-require 'trollop'
+require 'optimist'
 require "sup"
 
 PROGRESS_UPDATE_INTERVAL = 15 # seconds
@@ -30,7 +30,7 @@ def time
   Time.now - startt
 end
 
-opts = Trollop::options do
+opts = Optimist::options do
   version "sup-sync (sup #{Redwood::VERSION})"
   banner <<EOS
 Synchronizes the Sup index with one or more message sources by adding
@@ -112,7 +112,7 @@ begin
     Redwood::SourceManager.usual_sources
   else
     ARGV.map do |uri|
-      Redwood::SourceManager.source_for uri or Trollop::die "Unknown source: #{uri}. Did you add it with sup-add first?"
+      Redwood::SourceManager.source_for uri or Optimist::die "Unknown source: #{uri}. Did you add it with sup-add first?"
     end
   end
 

--- a/bin/sup-sync-back-maildir
+++ b/bin/sup-sync-back-maildir
@@ -3,10 +3,10 @@
 
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
-require 'trollop'
+require 'optimist'
 require "sup"
 
-opts = Trollop::options do
+opts = Optimist::options do
   version "sup-sync-back-maildir (sup #{Redwood::VERSION})"
   banner <<EOS
 Export Xapian entries to Maildir sources on disk.

--- a/bin/sup-tweak-labels
+++ b/bin/sup-tweak-labels
@@ -2,7 +2,7 @@
 
 $:.unshift File.join(File.dirname(__FILE__), *%w[.. lib])
 
-require 'trollop'
+require 'optimist'
 require "sup"
 
 class Float
@@ -25,7 +25,7 @@ def time
   Time.now - startt
 end
 
-opts = Trollop::options do
+opts = Optimist::options do
   version "sup-tweak-labels (sup #{Redwood::VERSION})"
   banner <<EOS
 Batch modification of message state for messages already in the index.
@@ -58,7 +58,7 @@ opts[:verbose] = true if opts[:very_verbose]
 add_labels = opts[:add].to_set_of_symbols ","
 remove_labels = opts[:remove].to_set_of_symbols ","
 
-Trollop::die "nothing to do: no labels to add or remove" if add_labels.empty? && remove_labels.empty?
+Optimist::die "nothing to do: no labels to add or remove" if add_labels.empty? && remove_labels.empty?
 
 Redwood::start
 index = Redwood::Index.init
@@ -71,10 +71,10 @@ begin
     Redwood::SourceManager.sources
   else
     ARGV.map do |uri|
-      Redwood::SourceManager.source_for uri or Trollop::die "Unknown source: #{uri}. Did you add it with sup-add first?"
+      Redwood::SourceManager.source_for uri or Optimist::die "Unknown source: #{uri}. Did you add it with sup-add first?"
     end
   end.map { |s| s.id }
-  Trollop::die "nothing to do: no sources" if source_ids.empty?
+  Optimist::die "nothing to do: no sources" if source_ids.empty?
 
   query = "(" + source_ids.map { |id| "source_id:#{id}" }.join(" OR ") + ")"
   if add_labels.empty?

--- a/sup.gemspec
+++ b/sup.gemspec
@@ -53,7 +53,7 @@ SUP: please note that our old mailing lists have been shut down,
   s.add_runtime_dependency "ncursesw", "~> 1.4.0"
   s.add_runtime_dependency "rmail", "~> 1.1"
   s.add_runtime_dependency "highline"
-  s.add_runtime_dependency "trollop", ">= 1.12"
+  s.add_runtime_dependency "optimist"
   s.add_runtime_dependency "lockfile"
   s.add_runtime_dependency "mime-types", "> 2.0"
   s.add_runtime_dependency "locale", "~> 2.0"


### PR DESCRIPTION
The trollop gem is deprecated in favour of its new name, optimist.
The optimist 3.0.0 gem is a drop-in replacement for trollop, this patch
is just a find-replace trollop -> optimist.

Fixes #554.