### PR TITLE
don't apply shell escaping to attachment filenames when saving

### DIFF
--- a/lib/sup/message_chunks.rb
+++ b/lib/sup/message_chunks.rb
@@ -160,6 +160,7 @@ EOS
       end
     end
     def safe_filename; Shellwords.escape(@filename).gsub("/", "_") end
+    def filesafe_filename; @filename.gsub("/", "_") end
 
     ## an attachment is exapndable if we've managed to decode it into
     ## something we can display inline. otherwise, it's viewable.

--- a/lib/sup/modes/thread_view_mode.rb
+++ b/lib/sup/modes/thread_view_mode.rb
@@ -393,7 +393,7 @@ EOS
     when Chunk::Attachment
       default_dir = $config[:default_attachment_save_dir]
       default_dir = ENV["HOME"] if default_dir.nil? || default_dir.empty?
-      default_fn = File.expand_path File.join(default_dir, chunk.safe_filename)
+      default_fn = File.expand_path File.join(default_dir, chunk.filesafe_filename)
       fn = BufferManager.ask_for_filename :filename, "Save attachment to file or directory: ", default_fn, true
 
       # if user selects directory use file name from message
@@ -422,7 +422,7 @@ EOS
     num_errors = 0
     m.chunks.each do |chunk|
       next unless chunk.is_a?(Chunk::Attachment)
-      fn = File.join(folder, chunk.safe_filename)
+      fn = File.join(folder, chunk.filesafe_filename)
       num_errors += 1 unless save_to_file(fn, false) { |f| f.print chunk.raw_content }
       num += 1
     end


### PR DESCRIPTION
When we're saving attachments to disk, there is no shell involved, so
there is no need to escape spaces or other shell metacharacters. The
only character we need to escape is the directory separator.

Based on a patch contributed by
Felix Van der Jeugt
in PR #528.

Fixes #505.