### PR TITLE
Fix misinterpretation of quoted text from Zimbra clients

### DIFF
--- a/lib/sup/message.rb
+++ b/lib/sup/message.rb
@@ -691,7 +691,7 @@ private
           newstate = :quote
         elsif line =~ SIG_PATTERN && (lines.length - i) < MAX_SIG_DISTANCE && !lines[(i+1)..-1].index { |l| l =~ /^-- $/ }
           newstate = :sig
-        elsif line =~ BLOCK_QUOTE_PATTERN
+        elsif line =~ BLOCK_QUOTE_PATTERN && nextline !~ QUOTE_PATTERN
           newstate = :block_quote
         end
 

--- a/test/fixtures/zimbra-quote-with-bottom-post.eml
+++ b/test/fixtures/zimbra-quote-with-bottom-post.eml
@@ -1,0 +1,27 @@
+Return-Path: <zimbra.user@example.invalid>
+Delivered-To: <recipient@example.invalid>
+Received: from zmail16.collab.prod.int.phx2.redhat.com (zmail16.collab.prod.int.phx2.redhat.com [10.5.83.18])
+    by mx4-phx2.redhat.com (8.13.8/8.13.8) with ESMTP id q3A5xQ06025053
+    for <recipient@example.invalid>; Tue, 10 Apr 2012 01:59:26 -0400
+Date: Tue, 10 Apr 2012 01:59:26 -0400 (EDT)
+From: Zimbra User <zimbra.user@example.invalid>
+To: Recipient <recipient@example.invalid>
+Subject: Re: Zimbra
+Message-ID: <0fe105df-e67b-419e-8599-50aaff7260e8@zmail16.collab.prod.int.phx2.redhat.com>
+In-Reply-To: <1334037315-sup-8577@example.invalid>
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+MIME-Version: 1.0
+X-Mailer: Zimbra 7.1.2_GA_3268 (ZimbraWebClient - FF3.0 (Linux)/7.1.2_GA_3268)
+
+----- Original Message -----
+> From: "Recipient" <recipient@example.invalid>
+> To: "Zimbra User" <zimbra.user@example.invalid>
+> Sent: Tuesday, April 10, 2012 3:56:15 PM
+> Subject: Re: Zimbra
+>
+> This is the quoted original message.
+>
+
+
+This is the reply from the Zimbra user.


### PR DESCRIPTION
This was an old patch from a colleague, which I've been carrying in my sup tree (for almost 10 years, yikes!).

I think this was posted to the old Gitorious repo but never merged. I've added a test case to illustrate the fixed behaviour.