### PR TITLE
xapian-ruby 1.4 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org/'
 
 if !RbConfig::CONFIG['arch'].include?('openbsd')
   # update version in ext/mkrf_conf_xapian.rb as well.
-  gem 'xapian-ruby', '~> 1.2.0'
+  gem 'xapian-ruby', '~> 1.2'
 end
 
 gemspec

--- a/ext/mkrf_conf_xapian.rb
+++ b/ext/mkrf_conf_xapian.rb
@@ -16,7 +16,7 @@ begin
   if !RbConfig::CONFIG['arch'].include?('openbsd')
     # update version in Gemfile as well
     name    = "xapian-ruby"
-    version = "~> 1.2.0"
+    version = "~> 1.2"
 
     begin
       # try to load gem

--- a/test/unit/util/test_query.rb
+++ b/test/unit/util/test_query.rb
@@ -24,9 +24,14 @@ describe Redwood::Util::Query do
       query = Xapian::Query.new msg
       life = 'hæi'
 
-      # this is now possibly UTF-8 string with possibly invalid chars
-      assert_raises Redwood::Util::Query::QueryDescriptionError do
-        desc = Redwood::Util::Query.describe (query)
+      if query.description.force_encoding("UTF-8").valid_encoding?
+        # xapian 1.4 internally handles this bad input
+        assert true
+      else
+        # xapian 1.2 doesn't handle this bad input, so we do
+        assert_raises Redwood::Util::Query::QueryDescriptionError do
+          desc = Redwood::Util::Query.describe (query)
+        end
       end
 
       assert_raises Encoding::CompatibilityError do
@@ -40,7 +45,8 @@ describe Redwood::Util::Query do
 
       desc = Redwood::Util::Query.describe(query, "invalid query")
 
-      assert_equal("invalid query", desc)
+      assert desc.force_encoding("UTF-8").valid_encoding?
+
     end
   end
 end


### PR DESCRIPTION
Xapian changed its behaviour in version 1.4, and now internally handles broken (invalid UTF-8) query input.

Demonstration of the different Xapian behaviour (Ruby with `xapian-ruby` installed, whether or not sup is installed):

```ruby
require "xapian"
query = Xapian::Query.new "asdfa \xc3\x28åasdf"
puts query.description.force_encoding("UTF-8").valid_encoding?
```

With `xapian-ruby` 1.2, this returns `"false"` - and `Redwood::Util::Query` explicitly handles this case (commit 256e36a).

With `xapian-ruby` 1.4, this returns `"true"` - indicating that Xapian has internally handled the bad input, so no need for the special handling within `Redwood::Util::Query` (i.e., no need to throw `Redwood::Util::Query::QueryDescriptionError` anymore).

The change in Xapian behaviour caused two unit tests in `test/unit/util/test_query.rb` to fail, both intended to verify the special handling within `Redwood::Util::Query`:
* "returns a valid UTF-8 description of bad input"
* "returns a valid UTF-8 fallback description of bad input"

In this PR, we:

1. Revert the changes to `Gemfile` and `ext/mkrf_conf_xapian.rb` from 740e317, and again require `xapian-ruby '~> 1.2'` (instead of `'~> 1.2.0'` which forced 1.2.x).

2. Fix the failing tests, by allowing the invalid UTF-8 input to be handled by either `xapian-ruby` (`Xapian::Query`) or sup (`Redwood::Util::Query`).

Thank you also to @gernotkogler for merging <https://github.com/garaio/xapian-ruby/pull/6> and publishing `xapian-ruby` 1.4.16 to RubyGems: <https://rubygems.org/gems/xapian-ruby/versions/1.4.16>. This resolved the problem in previous version 1.4.9, which failed to build on Ruby 2.7.