### PR TITLE
use Unicode::DisplayWidth to handle basic emoji

### DIFF
--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -8,6 +8,7 @@ require 'set'
 require 'enumerator'
 require 'benchmark'
 require 'unicode'
+require 'unicode/display_width'
 require 'fileutils'
 
 class Lockfile
@@ -239,22 +240,12 @@ end
 
 class String
   def display_length
-    @display_length ||= Unicode.width(self.fix_encoding!, false)
-
-    # if Unicode.width fails and returns -1, fall back to
-    # regular String#length, see pull-request: #256.
-    if @display_length < 0
-      @display_length = self.length
-    end
-
-    @display_length
+    @display_length ||= Unicode::DisplayWidth.of(self)
   end
 
   def slice_by_display_length len
     each_char.each_with_object "" do |c, buffer|
-      width = Unicode.width(c, false)
-      width = 1 if width < 0
-      len -= width
+      len -= Unicode::DisplayWidth.of(c)
       return buffer if len < 0
       buffer << c
     end

--- a/sup.gemspec
+++ b/sup.gemspec
@@ -59,6 +59,7 @@ SUP: please note that our old mailing lists have been shut down,
   s.add_runtime_dependency "locale", "~> 2.0"
   s.add_runtime_dependency "chronic", "~> 0.9.1"
   s.add_runtime_dependency "unicode", "~> 0.4.4"
+  s.add_runtime_dependency "unicode-display_width"
 
   s.add_development_dependency "bundler", ">= 1.3", "< 3"
   s.add_development_dependency "rake"

--- a/test/unit/util/test_string.rb
+++ b/test/unit/util/test_string.rb
@@ -11,6 +11,8 @@ describe "Sup's String extension" do
         ['some words', 10,],
         ['中文', 4,],
         ['ä', 1,],
+        ['😱', 2],
+        #['🏳️‍🌈', 2],  # Emoji ZWJ sequence not yet supported (see PR #563)
       ]
     end
 
@@ -27,6 +29,8 @@ describe "Sup's String extension" do
         ['some words', 6, 'some w'],
         ['中文', 2, '中'],
         ['älpha', 3, 'älp'],
+        ['😱😱', 2, '😱'],
+        #['🏳️‍🌈', 2, '🏳️‍🌈'],  # Emoji ZWJ sequence not yet supported (see PR #563)
       ]
     end
 
@@ -45,6 +49,8 @@ describe "Sup's String extension" do
         ['中文', 2, ['中', '文']],
         ['中文', 5, ['中文']],
         ['älpha', 3, ['älp', 'ha']],
+        ['😱😱', 2, ['😱', '😱']],
+        #['🏳️‍🌈🏳️‍🌈', 2, ['🏳️‍🌈', '🏳️‍🌈']],  # Emoji ZWJ sequence not yet supported (see PR #563)
       ]
     end
 


### PR DESCRIPTION
This fixes display glitches which can occur when the sender name or
subject line contain emoji.

We intentionally avoid using the unicode-display_width gem's optional
emoji support, because that turns out to be prohibitively slow for these
methods which are in the hot path of rendering the message list. With
this patch we will still count basic emoji characters themselves as
double-width. As far as I can tell, the only consequence of avoiding the
extra emoji support is that we will *overestimate* the length of emoji
ZWJ sequences. That's not the end of the world, since we are just
truncating strings here. And many terminal emulators still can't render
emoji ZWJ sequences correctly anyway.

The Unicode::DisplayWidth.of method is careful to always return
a value greater than zero so we can simplify the code on our side
a bit too.