### PR TITLE
relax chronic version requirement

### DIFF
--- a/sup.gemspec
+++ b/sup.gemspec
@@ -57,7 +57,7 @@ SUP: please note that our old mailing lists have been shut down,
   s.add_runtime_dependency "lockfile"
   s.add_runtime_dependency "mime-types", "> 2.0"
   s.add_runtime_dependency "locale", "~> 2.0"
-  s.add_runtime_dependency "chronic", "~> 0.9.1"
+  s.add_runtime_dependency "chronic"
   s.add_runtime_dependency "unicode", "~> 0.4.4"
 
   s.add_development_dependency "bundler", ">= 1.3", "< 3"


### PR DESCRIPTION
The latest release of the chronic gem is 0.10.2 and it has been out for
a long time. Sup works fine with it.

To keep things simple, let's just relax the version requirement
entirely. It seems unlikely chronic will publish
a backwards-incompatible version in future.