### PR TITLE
Update links in gemspec and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Sup is a console-based email client for people with a lot of email.
 
 > Note: Sup is currently un-maintained. Please see [this discussion](https://github.com/sup-heliotrope/sup/issues/504). The [notmuch mail](https://notmuchmail.org/) project and its associated [clients](https://notmuchmail.org/frontends/) were inspired by sup and are actively maintained and developed.
 
-<img src="http://sup-heliotrope.github.io/images/old_screenshot_1.png" />
+<img src="https://sup-heliotrope.github.io/images/old_screenshot_1.png" />
 
 ## Installation
 
@@ -33,11 +33,11 @@ Current limitations:
 
 ## Problems
 
-Please report bugs to the [Github issue tracker](https://github.com/sup-heliotrope/sup/issues).
+Please report bugs to the [GitHub issue tracker](https://github.com/sup-heliotrope/sup/issues).
 
 ## Links
 
-* [Homepage](http://sup-heliotrope.github.io/)
+* [Homepage](https://sup-heliotrope.github.io/)
 * [Code repository](https://github.com/sup-heliotrope/sup)
 * [Wiki](https://github.com/sup-heliotrope/sup/wiki)
 * IRC: [#sup @ freenode.net](http://webchat.freenode.net/?channels=#sup)

--- a/sup.gemspec
+++ b/sup.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.authors = ["William Morgan", "Gaute Hope", "Hamish Downer", "Matthieu Rakotojaona"]
   s.email   = "supmua@googlegroups.com"
   s.summary = "A console-based email client with the best features of GMail, mutt and Emacs"
-  s.homepage = "http://supmua.org"
+  s.homepage = "https://sup-heliotrope.github.io/"
   s.license = 'GPL-2.0'
   s.description = <<-DESC
     Sup is a console-based email client for people with a lot of email.


### PR DESCRIPTION
- gemspec: Replace defunct homepage with <https://sup-heliotrope.github.io/>
- README: Use "https" for all GitHub links
- README: Typo fix, s/Github/GitHub/