### PR TITLE
fix Encoding::CompatibilityError when nested message/rfc822 parts contain non-ASCII header bytes

### DIFF
--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -120,23 +120,6 @@ module RMail
   end
 
   class Header
-
-    # Convert to ASCII before trying to match with regexp
-    class Field
-
-      class << self
-        def parse(field)
-          field = field.dup.to_s
-          field = field.fix_encoding!.ascii
-          if field =~ EXTRACT_FIELD_NAME_RE
-            [ $1, $'.chomp ]
-          else
-            [ "", Field.value_strip(field) ]
-          end
-        end
-      end
-    end
-
     ## Be more cautious about invalid content-type headers
     ## the original RMail code calls
     ## value.strip.split(/\s*;\s*/)[0].downcase

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -376,7 +376,6 @@ class String
   end
 
   def normalize_whitespace
-    fix_encoding!
     gsub(/\t/, "    ").gsub(/\r/, "")
   end
 

--- a/sup.gemspec
+++ b/sup.gemspec
@@ -51,7 +51,7 @@ SUP: please note that our old mailing lists have been shut down,
   ## ext/mkrf_conf_xapian.rb and Gemfile.
 
   s.add_runtime_dependency "ncursesw", "~> 1.4.0"
-  s.add_runtime_dependency "rmail", "~> 1.1"
+  s.add_runtime_dependency "rmail", ">= 1.1.2", "< 2"
   s.add_runtime_dependency "highline"
   s.add_runtime_dependency "optimist"
   s.add_runtime_dependency "lockfile"

--- a/test/fixtures/non-ascii-header-in-nested-message.eml
+++ b/test/fixtures/non-ascii-header-in-nested-message.eml
@@ -1,0 +1,36 @@
+Return-Path: <spammer@example.com>
+From: SPAM ® <spammer@example.com>
+To: <a@b.c>
+Subject: spam ® spam
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="----------=_4F506AC2.EE281DC4"
+Message-Id: <20120302063755.0FE2122017@a.a.a.a>
+Date: Fri,  2 Mar 2012 07:37:55 +0100 (CET)
+
+This is a multi-part message in MIME format.
+
+------------=_4F506AC2.EE281DC4
+Content-Type: text/plain; charset=iso-8859-1
+Content-Disposition: inline
+Content-Transfer-Encoding: 8bit
+
+Spam detection software, running on the system "a.a.a.a.a.", has
+identified this incoming email as possible spam.  The original message
+has been attached to this so you can view it (if it isn't spam) or label
+similar future email.
+
+
+------------=_4F506AC2.EE281DC4
+Content-Type: message/rfc822; x-spam-type=original
+Content-Description: original message before SpamAssassin
+Content-Disposition: attachment
+Content-Transfer-Encoding: 8bit
+
+From: SPAM ® <spammer@example.com>
+To: <a@b.c>
+Subject: spam ® spam
+
+This is a spam.
+
+------------=_4F506AC2.EE281DC4--
+

--- a/test/fixtures/non-ascii-header.eml
+++ b/test/fixtures/non-ascii-header.eml
@@ -1,0 +1,8 @@
+Return-Path: <spammer@example.com>
+From: SPAM ® <spammer@example.com>
+To: <a@b.c>
+Subject: spam ® spam
+Message-Id: <20120302063755.0FE2122017@a.a.a.a>
+Date: Fri,  2 Mar 2012 07:37:55 +0100 (CET)
+
+https://github.com/sup-heliotrope/sup/issues/205

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,9 +2,12 @@ require "rubygems" rescue nil
 require 'minitest/autorun'
 require "rr"
 
-def fixture(filename)
+def fixture_path(filename)
+  File.expand_path("../fixtures/#{filename}", __FILE__)
+end
+
+def fixture_contents(filename)
   file = ''
-  path = File.expand_path("../fixtures/#{filename}", __FILE__)
-  File.open(path) { |io| file = io.read }
+  File.open(fixture_path(filename)) { |io| file = io.read }
   file
 end

--- a/test/test_message.rb
+++ b/test/test_message.rb
@@ -232,6 +232,22 @@ class TestMessage < Minitest::Test
 
   end
 
+  def test_nonascii_header
+    ## Headers are supposed to be 7-bit ASCII, with non-ASCII characters encoded
+    ## using RFC2047 header encoding. But spammers sometimes send high bytes in
+    ## the headers. They will be replaced with U+FFFD REPLACEMENT CHARACTER.
+    source = DummySource.new("sup-test://test_nonascii_header")
+    source.messages = [ fixture_path("non-ascii-header.eml") ]
+    source_info = 0
+
+    sup_message = Message.build_from_source(source, source_info)
+    sup_message.load_from_source!
+
+    assert_equal("SPAM \ufffd", sup_message.from.name)
+    assert_equal("spammer@example.com", sup_message.from.email)
+    assert_equal("spam \ufffd spam", sup_message.subj)
+  end
+
   def test_malicious_attachment_names
     source = DummySource.new("sup-test://test_blank_header_lines")
     source.messages = [ fixture_path('malicious-attachment-names.eml') ]

--- a/test/test_message.rb
+++ b/test/test_message.rb
@@ -248,6 +248,29 @@ class TestMessage < Minitest::Test
     assert_equal("spam \ufffd spam", sup_message.subj)
   end
 
+  def test_nonascii_header_in_nested_message
+    source = DummySource.new("sup-test://test_nonascii_header_in_nested_message")
+    source.messages = [ fixture_path("non-ascii-header-in-nested-message.eml") ]
+    source_info = 0
+
+    sup_message = Message.build_from_source(source, source_info)
+    chunks = sup_message.load_from_source!
+
+    assert_equal(3, chunks.length)
+
+    assert(chunks[0].is_a? Redwood::Chunk::Text)
+
+    assert(chunks[1].is_a? Redwood::Chunk::EnclosedMessage)
+    ## TODO need to fix EnclosedMessage#lines
+    #assert_equal(4, chunks[1].lines.length)
+    #assert_equal("From: SPAM \ufffd <spammer@example.com>", chunks[1].lines[0])
+    #assert_equal("spam \ufffd spam", chunks[1].lines[3])
+
+    assert(chunks[2].is_a? Redwood::Chunk::Text)
+    assert_equal(1, chunks[2].lines.length)
+    assert_equal("This is a spam.", chunks[2].lines[0])
+  end
+
   def test_malicious_attachment_names
     source = DummySource.new("sup-test://test_blank_header_lines")
     source.messages = [ fixture_path('malicious-attachment-names.eml') ]

--- a/test/test_message.rb
+++ b/test/test_message.rb
@@ -21,10 +21,8 @@ class TestMessage < Minitest::Test
   end
 
   def test_simple_message
-    message = fixture('simple-message.eml')
-
     source = DummySource.new("sup-test://test_simple_message")
-    source.messages = [ message ]
+    source.messages = [ fixture_path('simple-message.eml') ]
     source_info = 0
 
     sup_message = Message.build_from_source(source, source_info)
@@ -99,10 +97,8 @@ class TestMessage < Minitest::Test
   end
 
   def test_multipart_message
-    message = fixture('multi-part.eml')
-
     source = DummySource.new("sup-test://test_multipart_message")
-    source.messages = [ message ]
+    source.messages = [ fixture_path('multi-part.eml') ]
     source_info = 0
 
     sup_message = Message.build_from_source(source, source_info)
@@ -126,10 +122,8 @@ class TestMessage < Minitest::Test
   end
 
   def test_broken_message_1
-    message = fixture('missing-from-to.eml')
-
     source = DummySource.new("sup-test://test_broken_message_1")
-    source.messages = [ message ]
+    source.messages = [ fixture_path('missing-from-to.eml') ]
     source_info = 0
 
     sup_message = Message.build_from_source(source, source_info)
@@ -150,10 +144,8 @@ class TestMessage < Minitest::Test
   end
 
   def test_broken_message_2
-    message = fixture('no-body.eml')
-
     source = DummySource.new("sup-test://test_broken_message_1")
-    source.messages = [ message ]
+    source.messages = [ fixture_path('no-body.eml') ]
     source_info = 0
 
     sup_message = Message.build_from_source(source, source_info)
@@ -167,10 +159,8 @@ class TestMessage < Minitest::Test
   end
 
   def test_multipart_message_2
-    message = fixture('multi-part-2.eml')
-
     source = DummySource.new("sup-test://test_multipart_message_2")
-    source.messages = [ message ]
+    source.messages = [ fixture_path('multi-part-2.eml') ]
     source_info = 0
 
     sup_message = Message.build_from_source(source, source_info)
@@ -182,10 +172,8 @@ class TestMessage < Minitest::Test
   end
 
   def test_text_attachment_decoding
-    message = fixture('text-attachments-with-charset.eml')
-
     source = DummySource.new("sup-test://test_text_attachment_decoding")
-    source.messages = [ message ]
+    source.messages = [ fixture_path('text-attachments-with-charset.eml') ]
     source_info = 0
 
     sup_message = Message.build_from_source(source, source_info)
@@ -210,10 +198,8 @@ class TestMessage < Minitest::Test
   end
 
   def test_mailing_list_header
-    message = fixture('mailing-list-header.eml')
-
     source = DummySource.new("sup-test://test_mailing_list_header")
-    source.messages = [ message ]
+    source.messages = [ fixture_path('mailing-list-header.eml') ]
     source_info = 0
 
     sup_message = Message.build_from_source(source, source_info)
@@ -227,10 +213,8 @@ class TestMessage < Minitest::Test
   end
 
   def test_blank_header_lines
-    message = fixture('blank-header-fields.eml')
-
     source = DummySource.new("sup-test://test_blank_header_lines")
-    source.messages = [ message ]
+    source.messages = [ fixture_path('blank-header-fields.eml') ]
     source_info = 0
 
     sup_message = Message.build_from_source(source, source_info)
@@ -249,10 +233,8 @@ class TestMessage < Minitest::Test
   end
 
   def test_malicious_attachment_names
-    message = fixture('malicious-attachment-names.eml')
-
     source = DummySource.new("sup-test://test_blank_header_lines")
-    source.messages = [ message ]
+    source.messages = [ fixture_path('malicious-attachment-names.eml') ]
     source_info = 0
 
     sup_message = Message.build_from_source(source, source_info)
@@ -276,10 +258,8 @@ class TestMessage < Minitest::Test
     # tries to do the right thing and reply after the quote.
     # In this case we want to just look at the > markers when determining where
     # the quoted chunk ends.
-    message = fixture('zimbra-quote-with-bottom-post.eml')
-
     source = DummySource.new("sup-test://test_zimbra_quote_with_bottom_post")
-    source.messages = [ message ]
+    source.messages = [ fixture_path('zimbra-quote-with-bottom-post.eml') ]
     source_info = 0
 
     sup_message = Message.build_from_source(source, source_info)

--- a/test/test_messages_dir.rb
+++ b/test/test_messages_dir.rb
@@ -21,11 +21,8 @@ class TestMessagesDir < ::Minitest::Test
   end
 
   def test_binary_content_transfer_encoding
-    message = ''
-    File.open('test/fixtures/binary-content-transfer-encoding-2.eml') { |f| message = f.read }
-
     source = DummySource.new("sup-test://test_messages")
-    source.messages = [ message ]
+    source.messages = [ fixture_path('binary-content-transfer-encoding-2.eml') ]
     source_info = 0
 
     sup_message = Message.build_from_source(source, source_info)
@@ -53,11 +50,8 @@ class TestMessagesDir < ::Minitest::Test
   end
 
   def test_bad_content_transfer_encoding
-    message = ''
-    File.open('test/fixtures/bad-content-transfer-encoding-1.eml') { |f| message = f.read }
-
     source = DummySource.new("sup-test://test_messages")
-    source.messages = [ message ]
+    source.messages = [ fixture_path('bad-content-transfer-encoding-1.eml') ]
     source_info = 0
 
     sup_message = Message.build_from_source(source, source_info)
@@ -85,11 +79,8 @@ class TestMessagesDir < ::Minitest::Test
   end
 
   def test_missing_line
-    message = ''
-    File.open('test/fixtures/missing-line.eml') { |f| message = f.read }
-
     source = DummySource.new("sup-test://test_messages")
-    source.messages = [ message ]
+    source.messages = [ fixture_path('missing-line.eml') ]
     source_info = 0
 
     sup_message = Message.build_from_source(source, source_info)


### PR DESCRIPTION
Fixes the remaining crash in #205.