### PR TITLE
fix EnclosedMessage header lines (fixes #571)

### DIFF
--- a/lib/sup/message_chunks.rb
+++ b/lib/sup/message_chunks.rb
@@ -274,24 +274,19 @@ EOS
   class EnclosedMessage
     attr_reader :lines
     def initialize from, to, cc, date, subj
-      @from = from ? "unknown sender" : from.full_address
-      @to = to ? "" : to.map { |p| p.full_address }.join(", ")
-      @cc = cc ? "" : cc.map { |p| p.full_address }.join(", ")
-      if date
-        @date = date.rfc822
-      else
-        @date = ""
-      end
-
+      @from = !from ? "unknown sender" : from.full_address
+      @to = !to ? "" : to.map { |p| p.full_address }.join(", ")
+      @cc = !cc ? "" : cc.map { |p| p.full_address }.join(", ")
+      @date = !date ? "" : date.rfc822
       @subj = subj
-
-      @lines = "\nFrom: #{from}\n"
-      @lines += "To: #{to}\n"
-      if !cc.empty?
-        @lines += "Cc: #{cc}\n"
-      end
-      @lines += "Date: #{date}\n"
-      @lines += "Subject: #{subj}\n\n"
+      @lines = [
+        "From: #{@from}",
+        "To: #{@to}",
+        "Cc: #{@cc}",
+        "Date: #{@date}",
+        "Subject: #{@subj}"
+      ]
+      @lines.delete_if{ |line| line == 'Cc: ' }
     end
 
     def inlineable?; false end

--- a/test/fixtures/non-ascii-header-in-nested-message.eml
+++ b/test/fixtures/non-ascii-header-in-nested-message.eml
@@ -1,6 +1,6 @@
 Return-Path: <spammer@example.com>
 From: SPAM ® <spammer@example.com>
-To: <a@b.c>
+To: <recipient@example.invalid>
 Subject: spam ® spam
 MIME-Version: 1.0
 Content-Type: multipart/mixed; boundary="----------=_4F506AC2.EE281DC4"
@@ -27,7 +27,7 @@ Content-Disposition: attachment
 Content-Transfer-Encoding: 8bit
 
 From: SPAM ® <spammer@example.com>
-To: <a@b.c>
+To: <enclosed@example.invalid>
 Subject: spam ® spam
 
 This is a spam.

--- a/test/test_message.rb
+++ b/test/test_message.rb
@@ -261,10 +261,10 @@ class TestMessage < Minitest::Test
     assert(chunks[0].is_a? Redwood::Chunk::Text)
 
     assert(chunks[1].is_a? Redwood::Chunk::EnclosedMessage)
-    ## TODO need to fix EnclosedMessage#lines
-    #assert_equal(4, chunks[1].lines.length)
-    #assert_equal("From: SPAM \ufffd <spammer@example.com>", chunks[1].lines[0])
-    #assert_equal("spam \ufffd spam", chunks[1].lines[3])
+    assert_equal(4, chunks[1].lines.length)
+    assert_equal("From: SPAM \ufffd <spammer@example.com>", chunks[1].lines[0])
+    assert_equal("To: enclosed <enclosed@example.invalid>", chunks[1].lines[1])
+    assert_equal("Subject: spam \ufffd spam", chunks[1].lines[3])
 
     assert(chunks[2].is_a? Redwood::Chunk::Text)
     assert_equal(1, chunks[2].lines.length)


### PR DESCRIPTION
In class `EnclosedMessage` (within `lib/sup/message_chunks.rb`):

* Ternary operator logic was backwards, e.g., setting `@from` to `"unknown sender"` if and only if `from` was truthy(!)

* `@lines` was constructed using local variables instead of instance variables, which (happily?) masked the effects of the above backwards ternary logic. But this also created issue #571: `Redwood::Person` object representations were shown directly to the user, rather than the human-friendly parsed strings intended to be shown by `Redwood::Person#full_address`.

* `@lines` was constructed as a single string (with literal line breaks), instead of following the normal convention of an array of lines. This hindered testability.

In this commit, we:

1. Fix the above three issues in `EnclosedMessage`.

2. Uncomment and expand upon the "TODO" tests for `EnclosedMessage` headers. These placeholders were added in PR #569, credit @danc86.

3. Modify `test/fixtures/non-ascii-header-in-nested-message.eml` to follow best practices for a testing email address, i.e., use reserved `.invalid` domain instead of `b.c` - to ensure that the testing email address remains invalid forever.