### PR TITLE
mkrf_conf_xapian.rb: Fallback to Gem.user_dir

### DIFF
--- a/ext/mkrf_conf_xapian.rb
+++ b/ext/mkrf_conf_xapian.rb
@@ -10,7 +10,8 @@ end
 
 puts "xapian: platform specific dependencies.."
 
-inst = Gem::DependencyInstaller.new
+destination = File.writable?(Gem.dir) ? Gem.dir : Gem.user_dir
+inst = Gem::DependencyInstaller.new(:install_dir => destination)
 begin
 
   if !RbConfig::CONFIG['arch'].include?('openbsd')
@@ -34,8 +35,8 @@ begin
     STDERR.puts "xapian: openbsd: you have to install xapian-core and xapian-bindings manually, have a look at: https://github.com/sup-heliotrope/sup/wiki/Installation%3A-OpenBSD"
   end
 
-rescue
-
+rescue StandardError => e
+  STDERR.puts "Unable to install #{name} gem: #{e.inspect}"
   exit(1)
 
 end


### PR DESCRIPTION
`ext/mkrf_conf_xapian.rb` didn't check writability of the requested gem installation directory before attempting to install the `xapian-ruby` gem.

In typical default configurations, this would cause installation of the `sup` gem to fail for non-root users (because of no write permission by non-root users to the default system-wide gem directory).

Examples of gem installation workarounds that were being used due to this:

* Run `gem install sup` as root user. Not recommended for many distributions due to potential conflicts with the distribution's own package manager.

* Manually install the `xapian-ruby` gem first before attempting to install the `sup` gem. Not ideal, because it adds a manual step to what should be an automatically-installed dependency.

* Explicitly set the `GEM_HOME` environment variable before calling `gem install`. Not ideal, because this shouldn't be required.

In this commit, we modify `ext/mkrf_conf_xapian.rb` to:

1. Check that the requested gem installation directory is writable. If not, then fallback to installing `xapian-ruby` into the user gem directory (`Gem.user_dir`) instead.

2. Improve error handling: output a useful error message to `STDERR` if the attempted installation of `xapian-ruby` fails for any reason.