### PR TITLE
fix deprecation warnings from Minitest

### DIFF
--- a/test/integration/test_mbox.rb
+++ b/test/integration/test_mbox.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class TestMbox < MiniTest::Test
+class TestMbox < Minitest::Test
 
   def setup
     @path = Dir.mktmpdir

--- a/test/test_header_parsing.rb
+++ b/test/test_header_parsing.rb
@@ -69,7 +69,7 @@ EOS
 
   def test_blank_lines
     h = Source.parse_raw_email_header StringIO.new("")
-    assert_equal nil, h["message-id"]
+    assert_nil h["message-id"]
   end
 
   def test_empty_headers

--- a/test/unit/test_horizontal_selector.rb
+++ b/test/unit/test_horizontal_selector.rb
@@ -13,18 +13,18 @@ describe Redwood::HorizontalSelector do
 
   it "init w/ the first value selected" do
     first_value = values.first
-    @selector.val.must_equal first_value
+    assert_equal first_value, @selector.val
   end
 
   it "stores value for selection" do
     second_value = values[1]
     @selector.set_to second_value
-    @selector.val.must_equal second_value
+    assert_equal second_value, @selector.val
   end
 
   describe "for unknown value" do
     it "cannot select unknown value" do
-      @selector.wont_be :can_set_to?, strange_value
+      assert_equal false, @selector.can_set_to?(strange_value)
     end
 
     it "refuses selecting unknown value" do
@@ -34,7 +34,7 @@ describe Redwood::HorizontalSelector do
         @selector.set_to strange_value
       end
 
-      @selector.val.must_equal old_value
+      assert_equal old_value, @selector.val
     end
   end
 end

--- a/test/unit/test_locale_fiddler.rb
+++ b/test/unit/test_locale_fiddler.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'sup/util/locale_fiddler'
 
-class TestFiddle < ::Minitest::Unit::TestCase
+class TestFiddle < Minitest::Test
   # TODO this is a silly test
   def test_fiddle_set_locale
     before = LocaleDummy.setlocale(6, nil).to_s

--- a/test/unit/util/test_string.rb
+++ b/test/unit/util/test_string.rb
@@ -18,7 +18,7 @@ describe "Sup's String extension" do
 
     it "calculates display length of a string" do
       data.each do |(str, length)|
-        str.display_length.must_equal length
+        assert_equal length, str.display_length
       end
     end
   end
@@ -36,7 +36,7 @@ describe "Sup's String extension" do
 
     it "slices string by display length" do
       data.each do |(str, length, sliced)|
-        str.slice_by_display_length(length).must_equal sliced
+        assert_equal sliced, str.slice_by_display_length(length)
       end
     end
   end
@@ -56,7 +56,7 @@ describe "Sup's String extension" do
 
     it "wraps string by display length" do
       data.each do |(str, length, wrapped)|
-        str.wrap(length).must_equal wrapped
+        assert_equal wrapped, str.wrap(length)
       end
     end
   end

--- a/test/unit/util/test_uri.rb
+++ b/test/unit/util/test_uri.rb
@@ -7,13 +7,13 @@ describe Redwood::Util::Uri do
     it "builds uri from hash" do
       components = {:path => "/var/mail/foo", :scheme => "mbox"}
       uri = Redwood::Util::Uri.build(components)
-      uri.to_s.must_equal "mbox:/var/mail/foo"
+      assert_equal "mbox:/var/mail/foo", uri.to_s
     end
 
     it "expands ~ in path" do
       components = {:path => "~/foo", :scheme => "maildir"}
       uri = Redwood::Util::Uri.build(components)
-      uri.to_s.must_equal "maildir:#{ENV["HOME"]}/foo"
+      assert_equal "maildir:#{ENV["HOME"]}/foo", uri.to_s
     end
   end
 end


### PR DESCRIPTION
This fixes a number of different deprecation warnings from Minitest:

```
WARNING: MiniTest::Unit::TestCase is now Minitest::Test. From test/unit/test_locale_fiddler.rb:5:in `<top (required)>'
```

```
WARNING: DEPRECATED: global use of must_equal from test/unit/util/test_uri.rb:10. Use _(obj).must_equal instead. This will fail in Minitest 6.
```

```
WARNING: DEPRECATED: Use assert_nil if expecting nil from test/test_header_parsing.rb:72. This will fail in Minitest 6.
```