### PR TITLE
Drop `git ls-files` in gemspec

### DIFF
--- a/sup.gemspec
+++ b/sup.gemspec
@@ -32,7 +32,7 @@ SUP: please note that our old mailing lists have been shut down,
      https://github.com/sup-heliotrope/sup/wiki/Installation%3A-OpenBSD.
   EOF
 
-  s.files         = `git ls-files -z`.split("\x0")
+  s.files         = File.read("Manifest.txt").split
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]


### PR DESCRIPTION
Hi @IPv2 and @danc86,

Thanks for the active maintenance of `sup` again! :heart: 
However, while maintaining this in Debian, we found that `sup` relies on `git` to list the files which could be done via pure Ruby alternative -- which is what this PR does.

As an addition, this PR makes sure that this gem only ships the required files to the end-users and not other things which are not needed by them! :rocket: 

Also, added `rubocop-packaging` as a `development_dependency` which will ensure the best practices (and therefore help us in the Debian maintenance!)
Here's what it shows us:

```
➜  sup git:(master)  rubocop --only Packaging

Offenses:

sup.gemspec:35:21: C: Packaging/GemspecGit: Avoid using git to produce lists of files.
Downstreams often need to build your package in an environment that does not have git (on purpose).
Use some pure Ruby alternative, like Dir or Dir.glob.
  s.files         = `git ls-files -z`.split("\x0")
                    ^^^^^^^^^^^^^^^^^

104 files inspected, 1 offense detected
```

And this PR fixes the same, which helps us in shipping this in Debian! :tada: 
Hope this would make sense and you'll be open to this change :100: 

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>