### PR TITLE
Add rubocop-packaging checks

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -23,6 +23,9 @@ bin/sup-tweak-labels
 contrib/colorpicker.rb
 contrib/completion/_sup.bash
 contrib/completion/_sup.zsh
+contrib/rubocop-packaging/.rubocop.yml
+contrib/rubocop-packaging/Gemfile
+contrib/rubocop-packaging/rubocop-packaging.sh
 devel/console.sh
 devel/count-loc.sh
 devel/load-index.rb

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ end
 task :default => :test
 
 task :build => [:man]
-task :travis => [:test, :check_manifest, :build]
+task :travis => [:test, :rubocop_packaging, :check_manifest, :build]
 
 def test_pandoc
   return system("pandoc -v > /dev/null 2>&1")
@@ -75,5 +75,22 @@ task :check_manifest do
     STDERR.puts "Manifest.txt outdated. Please commit an updated Manifest.txt"
     STDERR.puts "To generate Manifest.txt, run: rake manifest"
     abort "Manifest.txt does not match `git ls-files`"
+  end
+end
+
+task :rubocop_packaging do
+  # Bundler.with_clean_env allows rubocop-packaging.sh to use its own
+  # separate Bundler directory, even if this Rake task is executed by
+  # Bundler.
+  # 
+  # We currently use the deprecated "Bundler.with_clean_env" instead of
+  # "Bundler.with_unbundled_env" for compatibility with older versions
+  # of Ruby and Bundler.
+  Bundler.with_clean_env do
+    if system("cd contrib/rubocop-packaging && ./rubocop-packaging.sh")
+      puts "rubocop-packaging checks OK"
+    else
+      abort "rubocop-packaging checks failed"
+    end
   end
 end

--- a/contrib/rubocop-packaging/.rubocop.yml
+++ b/contrib/rubocop-packaging/.rubocop.yml
@@ -1,0 +1,5 @@
+require:
+  - rubocop-packaging
+
+AllCops:
+  DisabledByDefault: true

--- a/contrib/rubocop-packaging/Gemfile
+++ b/contrib/rubocop-packaging/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org/'
+
+gem 'rubocop-packaging'

--- a/contrib/rubocop-packaging/rubocop-packaging.sh
+++ b/contrib/rubocop-packaging/rubocop-packaging.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -euf
+
+if [ ! -f .rubocop.yml ]; then
+    echo ".rubocop.yml not found in current working directory: `pwd`" >&2
+    echo "To run, first 'cd' to the directory that contains this script" >&2
+    exit 1
+fi
+
+rm -f Gemfile.lock
+
+echo "[rubocop-packaging] Running 'bundle install'..."
+bundle install --path=.bundle
+
+echo "[rubocop-packaging] Running RuboCop Packaging checks"
+bundle exec rubocop --only Packaging ../..


### PR DESCRIPTION
`rubocop-packaging` automatically detects common packaging issues which may make life more difficult for downstream maintainers.

We add and execute off to the side, i.e., contained entirely within a new subdirectory inside `contrib`, including its own separate Bundler directory for gems. This is to avoid a hard development dependency in the main Sup project on the `rubocop-packaging` gem, because it is currently a very new project - started one month ago in 2020-06.

Rake task `rubocop_packaging` added to execute the checks. Called by task `travis`, used by Travis CI.

With thanks to Utkarsh Gupta \<utkarsh@debian.org\> for the original idea (see PR #580).