### PR TITLE
avoid URI.encode and URI.decode

### DIFF
--- a/bin/sup-add
+++ b/bin/sup-add
@@ -94,18 +94,14 @@ begin
       next
     end
 
-    parsed_uri = URI(URI.escape(uri))
-
     source =
-      case parsed_uri.scheme
-      when "maildir"
+      case uri
+      when /^maildir:/
         Redwood::Maildir.new uri, !$opts[:unusual], $opts[:archive], $opts[:sync_back], nil, labels
-      when "mbox"
+      when /^mbox:/
         Redwood::MBox.new uri, !$opts[:unusual], $opts[:archive], nil, labels
       when nil
-        Optimist::die "Sources must be specified with an URI"
-      else
-        Optimist::die "Unknown source type #{parsed_uri.scheme.inspect}"
+        Optimist::die "Sources must be specified with a maildir:// or mbox:// URI"
       end
     @cli.say "Adding #{source}..."
     Redwood::SourceManager.add_source source

--- a/lib/sup/maildir.rb
+++ b/lib/sup/maildir.rb
@@ -16,9 +16,9 @@ class Maildir < Source
     if parts
       prefix = parts[1]
       @path = parts[3]
-      uri = URI(prefix + URI.encode(@path, URI_ENCODE_CHARS))
+      uri = URI(prefix + Source.encode_path_for_uri(@path))
     else
-      uri = URI(URI.encode @expanded_uri, URI_ENCODE_CHARS)
+      uri = URI(Source.encode_path_for_uri @path)
       @path = uri.path
     end
 
@@ -30,7 +30,7 @@ class Maildir < Source
     # sync by default if not specified
     @sync_back = true if @sync_back.nil?
 
-    @dir = URI.decode uri.path
+    @dir = URI.decode_www_form_component uri.path
     @labels = Set.new(labels || [])
     @mutex = Mutex.new
     @ctimes = { 'cur' => Time.at(0), 'new' => Time.at(0) }

--- a/lib/sup/mbox.rb
+++ b/lib/sup/mbox.rb
@@ -23,9 +23,9 @@ class MBox < Source
       if parts
         prefix = parts[1]
         @path = parts[3]
-        uri = URI(prefix + URI.encode(@path, URI_ENCODE_CHARS))
+        uri = URI(prefix + Source.encode_path_for_uri(@path))
       else
-        uri = URI(URI.encode @expanded_uri, URI_ENCODE_CHARS)
+        uri = URI(Source.encode_path_for_uri @expanded_uri)
         @path = uri.path
       end
 
@@ -36,7 +36,7 @@ class MBox < Source
     else
       @f = uri_or_fp
       @path = uri_or_fp.path
-      @expanded_uri = "mbox://#{URI.encode @path, URI_ENCODE_CHARS}"
+      @expanded_uri = "mbox://#{Source.encode_path_for_uri @path}"
     end
 
     super uri_or_fp, usual, archived, id

--- a/lib/sup/source.rb
+++ b/lib/sup/source.rb
@@ -169,6 +169,12 @@ protected
   def Source.expand_filesystem_uri uri
     uri.gsub "~", File.expand_path("~")
   end
+
+  def Source.encode_path_for_uri path
+    path.gsub(Regexp.new("[#{Regexp.quote(URI_ENCODE_CHARS)}]")) { |c|
+      c.each_byte.map { |x| sprintf("%%%02X", x) }.join
+    }
+  end
 end
 
 ## if you have a @labels instance variable, include this


### PR DESCRIPTION
These methods were removed in Ruby 3.0.

Fixes #588.