### PR TITLE
handle UTF-7

### DIFF
--- a/lib/sup/message_chunks.rb
+++ b/lib/sup/message_chunks.rb
@@ -128,12 +128,16 @@ EOS
 
       text = case @content_type
       when /^text\/plain\b/
-        begin
-          charset = Encoding.find(encoded_content.charset || 'US-ASCII')
-        rescue ArgumentError
-          charset = 'US-ASCII'
+        if /^UTF-7$/i =~ encoded_content.charset
+          @raw_content.decode_utf7
+        else
+          begin
+            charset = Encoding.find(encoded_content.charset || 'US-ASCII')
+          rescue ArgumentError
+            charset = 'US-ASCII'
+          end
+          @raw_content.force_encoding(charset)
         end
-        @raw_content.force_encoding(charset)
       else
         HookManager.run "mime-decode", :content_type => @content_type,
                         :filename => lambda { write_to_disk },

--- a/lib/sup/rfc2047.rb
+++ b/lib/sup/rfc2047.rb
@@ -16,6 +16,8 @@
 #
 # This file is distributed under the same terms as Ruby.
 
+require 'net/imap'
+
 module Rfc2047
   WORD = %r{=\?([!\#$%&'*+-/0-9A-Z\\^\`a-z{|}~]+)\?([BbQq])\?([!->@-~ ]+)\?=} # :nodoc: 'stupid ruby-mode
   WORDSEQ = %r{(#{WORD.source})\s+(?=#{WORD.source})}
@@ -49,6 +51,10 @@ module Rfc2047
         # Don't need an else, because no other values can be matched in a
         # WORD.
       end
+
+      # Handle UTF-7 specially because Ruby doesn't actually support it as
+      # a normal character encoding.
+      next text.decode_utf7.encode(target) if charset == 'UTF-7'
 
       begin
         text.force_encoding(charset).encode(target)

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -375,6 +375,22 @@ class String
     self
   end
 
+  ## Decodes UTF-7 and returns the resulting decoded string as UTF-8.
+  ##
+  ## Ruby doesn't supply a UTF-7 encoding natively. There is
+  ## Net::IMAP::decode_utf7 which only handles the IMAP "modified UTF-7"
+  ## encoding. This implementation is inspired by that one but handles
+  ## standard UTF-7 shift characters and not the IMAP-specific variation.
+  def decode_utf7
+    gsub(/\+([^-]+)?-/) {
+      if $1
+        ($1 + "===").unpack("m")[0].encode(Encoding::UTF_8, Encoding::UTF_16BE)
+      else
+        "+"
+      end
+    }
+  end
+
   def normalize_whitespace
     gsub(/\t/, "    ").gsub(/\r/, "")
   end

--- a/test/fixtures/rfc2047-header-encoding.eml
+++ b/test/fixtures/rfc2047-header-encoding.eml
@@ -5,6 +5,7 @@ Subject:
  =?US-ASCII?q?Hans Martin Djupvik?= =?ISO-8859-1?q?,_Ingrid_B=F8?=
  =?KOI8-R?b?LCDp0snOwSDzycTP0s/XwQ?=
  =?UTF-16?b?//4sACAASgBlAHMAcABlAHIAIABCAGUAcgBnAA?=
+ =?UTF-7?b?LCBGcmlkYSBFbmcrQVBnLQ?=
  bad: =?UTF16?q?badcharsetname?= =?US-ASCII?b?/w?=
 
 The subject header contains various RFC2047 encoded words.

--- a/test/fixtures/text-attachments-with-charset.eml
+++ b/test/fixtures/text-attachments-with-charset.eml
@@ -50,4 +50,11 @@ Content-Disposition: attachment; filename="invalid-charset.txt"
 
 Example invalid charset
 --===============2385509127900810307==
+Content-Type: text/plain; charset="utf-7"
+Content-Transfer-Encoding: 7bit
+MIME-Version: 1.0
+Content-Disposition: attachment; filename="ascii.txt"
+
+This is +Jyg-UTF-7+Jyg-
+--===============2385509127900810307==
 

--- a/test/test_message.rb
+++ b/test/test_message.rb
@@ -180,7 +180,7 @@ class TestMessage < Minitest::Test
     sup_message.load_from_source!
 
     chunks = sup_message.load_from_source!
-    assert_equal(6, chunks.length)
+    assert_equal(7, chunks.length)
     assert(chunks[0].is_a? Redwood::Chunk::Text)
     ## The first attachment declares charset=us-ascii
     assert(chunks[1].is_a? Redwood::Chunk::Attachment)
@@ -199,6 +199,9 @@ class TestMessage < Minitest::Test
     ## be handled gracefully
     assert(chunks[5].is_a? Redwood::Chunk::Attachment)
     assert_equal(["Example invalid charset"], chunks[5].lines)
+    ## The sixth attachment is UTF-7 encoded
+    assert(chunks[6].is_a? Redwood::Chunk::Attachment)
+    assert_equal(["This is ✨UTF-7✨"], chunks[6].lines)
   end
 
   def test_mailing_list_header

--- a/test/test_message.rb
+++ b/test/test_message.rb
@@ -244,7 +244,8 @@ class TestMessage < Minitest::Test
     sup_message = Message.build_from_source(source, source_info)
     sup_message.load_from_source!
 
-    assert_equal("Hans Martin Djupvik, Ingrid Bø, Ирина Сидорова, Jesper Berg " +
+    assert_equal("Hans Martin Djupvik, Ingrid Bø, Ирина Сидорова, " +
+                 "Jesper Berg, Frida Engø " +
                  "bad: =?UTF16?q?badcharsetname?==?US-ASCII?b?/w?=",
                  sup_message.subj)
   end


### PR DESCRIPTION
I received some spam with UTF-7 RFC2047 in the Subject header. Yet
another spam filter evasion technique, presumably.

Decode it for completeness rather than crashing:

    Encoding::ConverterNotFoundError: code converter not found (UTF-7 to UTF-8)