### PR TITLE
console mode: fix deprecated usage of Enumerator.new

### DIFF
--- a/lib/sup/modes/console_mode.rb
+++ b/lib/sup/modes/console_mode.rb
@@ -11,7 +11,7 @@ class Console
   end
 
   def query(query)
-    Enumerator.new(Index.instance, :each_message, Index.parse_query(query))
+    Index.instance.enum_for :each_message, Index.parse_query(query)
   end
 
   def add_labels(query, *labels)


### PR DESCRIPTION
The 'query' method suffered a similar issue as #603, with a similar fix
as in PR #608.