### PR TITLE
use nix-shell in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,12 +17,6 @@ jobs:
         - ubuntu-latest
         - macos-latest
         ruby-version:
-        - '2.0'
-        - '2.1'
-        # Ruby 2.2 fails installing sup gem with a nonsensical error:
-        #   Could not find 'xapian-ruby' (~> 1.2) among 21 total gem(s)
-        #- '2.2'
-        - '2.3'
         - '2.4'
         - '2.5'
         - '2.6'
@@ -30,15 +24,6 @@ jobs:
         - '3.0'
         - '3.1'
         exclude:
-        # xapian-bindings 1.2.2 fails to build on MacOS:
-        #   clang: warning: include path for libstdc++ headers not found; pass
-        #   '-stdlib=libc++' on the command line to use the libc++ standard
-        #   library instead [-Wstdlibcxx-not-found]
-        #   xapian_wrap.cc:1836:10: fatal error: 'string' file not found
-        # Probably just wrong compiler command or some mess that I can't be
-        # bothered to figure out.
-        - os: macos-latest
-          ruby-version: '2.0'
         # xapian-bindings 1.4.18 fails to build with Ruby 3.0+ on MacOS:
         #   error: '__declspec' attributes are not enabled; use '-fdeclspec' or
         #   '-fms-extensions' to enable support for __declspec attributes

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,33 +23,16 @@ jobs:
         - '2.7'
         - '3.0'
         - '3.1'
-        exclude:
-        # xapian-bindings 1.4.18 fails to build with Ruby 3.0+ on MacOS:
-        #   error: '__declspec' attributes are not enabled; use '-fdeclspec' or
-        #   '-fms-extensions' to enable support for __declspec attributes
-        # Needs this fix:
-        # https://github.com/xapian/xapian/commit/63a06768a250b0bb4821b835f011e8214d560f8e
-        - os: macos-latest
-          ruby-version: '3.0'
-        - os: macos-latest
-          ruby-version: '3.1'
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Install pandoc
-      run: sudo apt-get install -y pandoc
-      if: runner.os == 'Linux'
-    - name: Install pandoc
-      run: brew install pandoc
-      if: runner.os == 'macOS'
-    - uses: actions/checkout@v3
+    - name: Check out source
+      uses: actions/checkout@v3
       with:
         submodules: recursive
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true
+    - name: Install bash on MacOS
+      run: brew install bash
+      if: runner.os == 'macOS'
+    - name: Install nix
+      uses: nixbuild/nix-quick-install-action@v21
     - name: Run Rake ci task
-      run: bundle exec rake ci
-    - name: Test gem installation
-      run: gem install pkg/sup-*.gem
+      run: nix-shell "contrib/nix/ruby${{ matrix.ruby-version }}-shell.nix" --run 'rake ci'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,15 +24,33 @@ jobs:
         - '3.0'
         - '3.1'
     runs-on: ${{ matrix.os }}
+    env:
+      nixfile: "contrib/nix/ruby${{ matrix.ruby-version }}-shell.nix"
     steps:
     - name: Check out source
       uses: actions/checkout@v3
       with:
         submodules: recursive
+    - name: Cache nix store
+      uses: actions/cache@v3
+      id: nix-cache
+      with:
+        path: /tmp/nixcache
+        key: nix-store-${{ matrix.os }}-ruby${{ matrix.ruby-version }}-${{ hashFiles('contrib/nix/**') }}
+        restore-keys: |
+          nix-store-${{ matrix.os }}-ruby${{ matrix.ruby-version }}-
+          nix-store-
     - name: Install bash on MacOS
       run: brew install bash
       if: runner.os == 'macOS'
     - name: Install nix
       uses: nixbuild/nix-quick-install-action@v21
+    - name: Import nix cache
+      run: |
+        if [ -f /tmp/nixcache ] ; then
+          nix-store --import </tmp/nixcache
+        fi
     - name: Run Rake ci task
-      run: nix-shell "contrib/nix/ruby${{ matrix.ruby-version }}-shell.nix" --run 'rake ci'
+      run: nix-shell "$nixfile" --run 'rake ci'
+    - name: Export nix cache
+      run: nix-store --export $(nix-store -qR $(nix-build --no-out-link "$nixfile" -A inputDerivation | tail -n1)) >/tmp/nixcache

--- a/Manifest.txt
+++ b/Manifest.txt
@@ -23,6 +23,19 @@ bin/sup-tweak-labels
 contrib/colorpicker.rb
 contrib/completion/_sup.bash
 contrib/completion/_sup.zsh
+contrib/nix/Gemfile
+contrib/nix/Gemfile.lock
+contrib/nix/gemset.nix
+contrib/nix/ruby2.4-Gemfile.lock
+contrib/nix/ruby2.4-gemset.nix
+contrib/nix/ruby2.4-shell.nix
+contrib/nix/ruby2.5-Gemfile.lock
+contrib/nix/ruby2.5-gemset.nix
+contrib/nix/ruby2.5-shell.nix
+contrib/nix/ruby2.6-shell.nix
+contrib/nix/ruby2.7-shell.nix
+contrib/nix/ruby3.0-shell.nix
+contrib/nix/ruby3.1-shell.nix
 devel/console.sh
 devel/count-loc.sh
 devel/load-index.rb
@@ -100,6 +113,7 @@ lib/sup/util/path.rb
 lib/sup/util/query.rb
 lib/sup/util/uri.rb
 lib/sup/version.rb
+shell.nix
 sup.gemspec
 test/dummy_source.rb
 test/fixtures/bad-content-transfer-encoding-1.eml

--- a/contrib/nix/Gemfile
+++ b/contrib/nix/Gemfile
@@ -1,0 +1,22 @@
+source "https://rubygems.org/"
+
+gem "xapian-ruby", "~> 1.2"
+gem "ncursesw", "~> 1.4.0"
+gem "rmail", ">= 1.1.2", "< 2"
+gem "highline"
+gem "optimist"
+gem "lockfile"
+gem "mime-types", "> 2.0"
+gem "locale", "~> 2.0"
+gem "chronic"
+gem "unicode", "~> 0.4.4"
+gem "unicode-display_width"
+gem "string-scrub" if /^2\.0\./ =~ RUBY_VERSION
+
+gem "bundler", ">= 1.3", "< 3"
+gem "rake"
+gem "minitest", "~> 5.5"
+gem "rr", "~> 1.1"
+gem "gpgme", ">= 2.0.2"
+gem "pry"
+gem "rubocop-packaging" unless /^2\.[012]\./ =~ RUBY_VERSION

--- a/contrib/nix/Gemfile.lock
+++ b/contrib/nix/Gemfile.lock
@@ -1,0 +1,83 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    chronic (0.10.2)
+    coderay (1.1.3)
+    gpgme (2.0.20)
+      mini_portile2 (~> 2.3)
+    highline (2.0.3)
+    json (2.6.2)
+    locale (2.1.3)
+    lockfile (2.1.3)
+    method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
+    mini_portile2 (2.8.0)
+    minitest (5.16.2)
+    ncursesw (1.4.10)
+    optimist (3.0.1)
+    parallel (1.22.1)
+    parser (3.1.2.0)
+      ast (~> 2.4.1)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    regexp_parser (2.5.0)
+    rexml (3.2.5)
+    rmail (1.1.4)
+    rr (1.2.1)
+    rubocop (1.32.0)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.19.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.19.1)
+      parser (>= 3.1.1.0)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
+    ruby-progressbar (1.11.0)
+    unicode (0.4.4.4)
+    unicode-display_width (2.2.0)
+    xapian-ruby (1.4.18)
+
+PLATFORMS
+  aarch64-linux
+  x86_64-darwin-17
+  x86_64-darwin-18
+  x86_64-darwin-19
+  x86_64-darwin-20
+  x86_64-darwin-21
+  x86_64-darwin-22
+  x86_64-linux
+
+DEPENDENCIES
+  bundler (>= 1.3, < 3)
+  chronic
+  gpgme (>= 2.0.2)
+  highline
+  locale (~> 2.0)
+  lockfile
+  mime-types (> 2.0)
+  minitest (~> 5.5)
+  ncursesw (~> 1.4.0)
+  optimist
+  pry
+  rake
+  rmail (>= 1.1.2, < 2)
+  rr (~> 1.1)
+  rubocop-packaging
+  unicode (~> 0.4.4)
+  unicode-display_width
+  xapian-ruby (~> 1.2)
+
+BUNDLED WITH
+   2.3.9

--- a/contrib/nix/gemset.nix
+++ b/contrib/nix/gemset.nix
@@ -1,0 +1,319 @@
+{
+  ast = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04nc8x27hlzlrr5c2gn7mar4vdr0apw5xg22wp6m8dx3wqr04a0y";
+      type = "gem";
+    };
+    version = "2.4.2";
+  };
+  chronic = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1hrdkn4g8x7dlzxwb1rfgr8kw3bp4ywg5l4y4i9c2g5cwv62yvvn";
+      type = "gem";
+    };
+    version = "0.10.2";
+  };
+  coderay = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jvxqxzply1lwp7ysn94zjhh57vc14mcshw1ygw14ib8lhc00lyw";
+      type = "gem";
+    };
+    version = "1.1.3";
+  };
+  gpgme = {
+    dependencies = ["mini_portile2"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xbgh9d8nbvsvyzqnd0mzhz0nr9hx4qn025kmz6d837lry4lc6gw";
+      type = "gem";
+    };
+    version = "2.0.20";
+  };
+  highline = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0yclf57n2j3cw8144ania99h1zinf8q3f5zrhqa754j6gl95rp9d";
+      type = "gem";
+    };
+    version = "2.0.3";
+  };
+  json = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0yk5d10yvspkc5jyvx9gc1a9pn1z8v4k2hvjk1l88zixwf3wf3cl";
+      type = "gem";
+    };
+    version = "2.6.2";
+  };
+  locale = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0997465kxvpxm92fiwc2b16l49mngk7b68g5k35ify0m3q0yxpdn";
+      type = "gem";
+    };
+    version = "2.1.3";
+  };
+  lockfile = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0dij3ijywylvfgrpi2i0k17f6w0wjhnjjw0k9030f54z56cz7jrr";
+      type = "gem";
+    };
+    version = "2.1.3";
+  };
+  method_source = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1pnyh44qycnf9mzi1j6fywd5fkskv3x7nmsqrrws0rjn5dd4ayfp";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  mime-types = {
+    dependencies = ["mime-types-data"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ipw892jbksbxxcrlx9g5ljq60qx47pm24ywgfbyjskbcl78pkvb";
+      type = "gem";
+    };
+    version = "3.4.1";
+  };
+  mime-types-data = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "003gd7mcay800k2q4pb2zn8lwwgci4bhi42v2jvlidm8ksx03i6q";
+      type = "gem";
+    };
+    version = "3.2022.0105";
+  };
+  mini_portile2 = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rapl1sfmfi3bfr68da4ca16yhc0pp93vjwkj7y3rdqrzy3b41hy";
+      type = "gem";
+    };
+    version = "2.8.0";
+  };
+  minitest = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "14a9ign0hj3z3j4cpfplj2djaskx3skzyx4fl3x53d7saxmhrgn1";
+      type = "gem";
+    };
+    version = "5.16.2";
+  };
+  ncursesw = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nc14wls1yiigz593vw7580hb99lf4n485axapiz6sqpg1jnlhcr";
+      type = "gem";
+    };
+    version = "1.4.10";
+  };
+  optimist = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vg2chy1cfmdj6c1gryl8zvjhhmb3plwgyh1jfnpq4fnfqv7asrk";
+      type = "gem";
+    };
+    version = "3.0.1";
+  };
+  parallel = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "07vnk6bb54k4yc06xnwck7php50l09vvlw1ga8wdz0pia461zpzb";
+      type = "gem";
+    };
+    version = "1.22.1";
+  };
+  parser = {
+    dependencies = ["ast"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xhfghgidj8cbdnqp01f7kvnrv1f60izpkd9dhxsvpdzkfsdg97d";
+      type = "gem";
+    };
+    version = "3.1.2.0";
+  };
+  pry = {
+    dependencies = ["coderay" "method_source"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0m445x8fwcjdyv2bc0glzss2nbm1ll51bq45knixapc7cl3dzdlr";
+      type = "gem";
+    };
+    version = "0.14.1";
+  };
+  rainbow = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0smwg4mii0fm38pyb5fddbmrdpifwv22zv3d3px2xx497am93503";
+      type = "gem";
+    };
+    version = "3.1.1";
+  };
+  rake = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15whn7p9nrkxangbs9hh75q585yfn66lv0v2mhj6q6dl6x8bzr2w";
+      type = "gem";
+    };
+    version = "13.0.6";
+  };
+  regexp_parser = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1rfd3q17p7q7pa67844q8b16ipy6ksh8mkzynpm1zldqbb9x4xm0";
+      type = "gem";
+    };
+    version = "2.5.0";
+  };
+  rexml = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "08ximcyfjy94pm1rhcx04ny1vx2sk0x4y185gzn86yfsbzwkng53";
+      type = "gem";
+    };
+    version = "3.2.5";
+  };
+  rmail = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0m5npkmv764m725wzjzasgf3k8q5anf3vfr6k2cac1xj6jc8lcqi";
+      type = "gem";
+    };
+    version = "1.1.4";
+  };
+  rr = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1n9g78ba4c2zzmz8cdb97c38h1xm0clircag00vbcxwqs4dq0ymp";
+      type = "gem";
+    };
+    version = "1.2.1";
+  };
+  rubocop = {
+    dependencies = ["json" "parallel" "parser" "rainbow" "regexp_parser" "rexml" "rubocop-ast" "ruby-progressbar" "unicode-display_width"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09k371m1l177ca8w70hfbjb1w0hasfb46pxp4w6yw92kk71akll2";
+      type = "gem";
+    };
+    version = "1.32.0";
+  };
+  rubocop-ast = {
+    dependencies = ["parser"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0h8q3gwqs8afshjd2l52ywf48md9rskr3q2y4fydgm536vvahjgm";
+      type = "gem";
+    };
+    version = "1.19.1";
+  };
+  rubocop-packaging = {
+    dependencies = ["rubocop"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bzjd1077v96pyp62jg7s8ndxqbdhfnrdpdnmgi7h88xw22fp5xf";
+      type = "gem";
+    };
+    version = "0.5.1";
+  };
+  ruby-progressbar = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "02nmaw7yx9kl7rbaan5pl8x5nn0y4j5954mzrkzi9i3dhsrps4nc";
+      type = "gem";
+    };
+    version = "1.11.0";
+  };
+  unicode = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1v8kxmq9i85agjpl7pnl72688901xhs8wxhmj6lpy16a8xz3nzxk";
+      type = "gem";
+    };
+    version = "0.4.4.4";
+  };
+  unicode-display_width = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nlfck6z986fngp0r74maswmyb1rcksc8xc3mfpw9cj23c3s8zwn";
+      type = "gem";
+    };
+    version = "2.2.0";
+  };
+  xapian-ruby = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1z8arjkd0nlj6zv9in2sihmbwpbd17a10lsv7nwii7z0jjscyxpp";
+      type = "gem";
+    };
+    version = "1.4.18";
+  };
+}

--- a/contrib/nix/ruby2.4-Gemfile.lock
+++ b/contrib/nix/ruby2.4-Gemfile.lock
@@ -1,0 +1,81 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    chronic (0.10.2)
+    coderay (1.1.3)
+    gpgme (2.0.20)
+      mini_portile2 (~> 2.3)
+    highline (2.0.3)
+    locale (2.1.3)
+    lockfile (2.1.3)
+    method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
+    mini_portile2 (2.8.0)
+    minitest (5.15.0)
+    ncursesw (1.4.10)
+    optimist (3.0.1)
+    parallel (1.20.1)
+    parser (3.1.2.0)
+      ast (~> 2.4.1)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    regexp_parser (2.5.0)
+    rexml (3.2.5)
+    rmail (1.1.4)
+    rr (1.2.1)
+    rubocop (1.12.1)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
+    ruby-progressbar (1.11.0)
+    unicode (0.4.4.4)
+    unicode-display_width (2.2.0)
+    xapian-ruby (1.4.18)
+
+PLATFORMS
+  aarch64-linux
+  x86_64-darwin-17
+  x86_64-darwin-18
+  x86_64-darwin-19
+  x86_64-darwin-20
+  x86_64-darwin-21
+  x86_64-darwin-22
+  x86_64-linux
+
+DEPENDENCIES
+  bundler (>= 1.3, < 3)
+  chronic
+  gpgme (>= 2.0.2)
+  highline
+  locale (~> 2.0)
+  lockfile
+  mime-types (> 2.0)
+  minitest (~> 5.5)
+  ncursesw (~> 1.4.0)
+  optimist
+  pry
+  rake
+  rmail (>= 1.1.2, < 2)
+  rr (~> 1.1)
+  rubocop-packaging
+  unicode (~> 0.4.4)
+  unicode-display_width
+  xapian-ruby (~> 1.2)
+
+BUNDLED WITH
+   2.2.20

--- a/contrib/nix/ruby2.4-gemset.nix
+++ b/contrib/nix/ruby2.4-gemset.nix
@@ -1,0 +1,309 @@
+{
+  ast = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04nc8x27hlzlrr5c2gn7mar4vdr0apw5xg22wp6m8dx3wqr04a0y";
+      type = "gem";
+    };
+    version = "2.4.2";
+  };
+  chronic = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1hrdkn4g8x7dlzxwb1rfgr8kw3bp4ywg5l4y4i9c2g5cwv62yvvn";
+      type = "gem";
+    };
+    version = "0.10.2";
+  };
+  coderay = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jvxqxzply1lwp7ysn94zjhh57vc14mcshw1ygw14ib8lhc00lyw";
+      type = "gem";
+    };
+    version = "1.1.3";
+  };
+  gpgme = {
+    dependencies = ["mini_portile2"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xbgh9d8nbvsvyzqnd0mzhz0nr9hx4qn025kmz6d837lry4lc6gw";
+      type = "gem";
+    };
+    version = "2.0.20";
+  };
+  highline = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0yclf57n2j3cw8144ania99h1zinf8q3f5zrhqa754j6gl95rp9d";
+      type = "gem";
+    };
+    version = "2.0.3";
+  };
+  locale = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0997465kxvpxm92fiwc2b16l49mngk7b68g5k35ify0m3q0yxpdn";
+      type = "gem";
+    };
+    version = "2.1.3";
+  };
+  lockfile = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0dij3ijywylvfgrpi2i0k17f6w0wjhnjjw0k9030f54z56cz7jrr";
+      type = "gem";
+    };
+    version = "2.1.3";
+  };
+  method_source = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1pnyh44qycnf9mzi1j6fywd5fkskv3x7nmsqrrws0rjn5dd4ayfp";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  mime-types = {
+    dependencies = ["mime-types-data"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ipw892jbksbxxcrlx9g5ljq60qx47pm24ywgfbyjskbcl78pkvb";
+      type = "gem";
+    };
+    version = "3.4.1";
+  };
+  mime-types-data = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "003gd7mcay800k2q4pb2zn8lwwgci4bhi42v2jvlidm8ksx03i6q";
+      type = "gem";
+    };
+    version = "3.2022.0105";
+  };
+  mini_portile2 = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rapl1sfmfi3bfr68da4ca16yhc0pp93vjwkj7y3rdqrzy3b41hy";
+      type = "gem";
+    };
+    version = "2.8.0";
+  };
+  minitest = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06xf558gid4w8lwx13jwfdafsch9maz8m0g85wnfymqj63x5nbbd";
+      type = "gem";
+    };
+    version = "5.15.0";
+  };
+  ncursesw = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nc14wls1yiigz593vw7580hb99lf4n485axapiz6sqpg1jnlhcr";
+      type = "gem";
+    };
+    version = "1.4.10";
+  };
+  optimist = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vg2chy1cfmdj6c1gryl8zvjhhmb3plwgyh1jfnpq4fnfqv7asrk";
+      type = "gem";
+    };
+    version = "3.0.1";
+  };
+  parallel = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0055br0mibnqz0j8wvy20zry548dhkakws681bhj3ycb972awkzd";
+      type = "gem";
+    };
+    version = "1.20.1";
+  };
+  parser = {
+    dependencies = ["ast"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xhfghgidj8cbdnqp01f7kvnrv1f60izpkd9dhxsvpdzkfsdg97d";
+      type = "gem";
+    };
+    version = "3.1.2.0";
+  };
+  pry = {
+    dependencies = ["coderay" "method_source"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0m445x8fwcjdyv2bc0glzss2nbm1ll51bq45knixapc7cl3dzdlr";
+      type = "gem";
+    };
+    version = "0.14.1";
+  };
+  rainbow = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0smwg4mii0fm38pyb5fddbmrdpifwv22zv3d3px2xx497am93503";
+      type = "gem";
+    };
+    version = "3.1.1";
+  };
+  rake = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15whn7p9nrkxangbs9hh75q585yfn66lv0v2mhj6q6dl6x8bzr2w";
+      type = "gem";
+    };
+    version = "13.0.6";
+  };
+  regexp_parser = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1rfd3q17p7q7pa67844q8b16ipy6ksh8mkzynpm1zldqbb9x4xm0";
+      type = "gem";
+    };
+    version = "2.5.0";
+  };
+  rexml = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "08ximcyfjy94pm1rhcx04ny1vx2sk0x4y185gzn86yfsbzwkng53";
+      type = "gem";
+    };
+    version = "3.2.5";
+  };
+  rmail = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0m5npkmv764m725wzjzasgf3k8q5anf3vfr6k2cac1xj6jc8lcqi";
+      type = "gem";
+    };
+    version = "1.1.4";
+  };
+  rr = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1n9g78ba4c2zzmz8cdb97c38h1xm0clircag00vbcxwqs4dq0ymp";
+      type = "gem";
+    };
+    version = "1.2.1";
+  };
+  rubocop = {
+    dependencies = ["parallel" "parser" "rainbow" "regexp_parser" "rexml" "rubocop-ast" "ruby-progressbar" "unicode-display_width"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0hi2c3a6alya9yx07nirnjzlc0mvmidnx67874njp6wf7d5xqqr9";
+      type = "gem";
+    };
+    version = "1.12.1";
+  };
+  rubocop-ast = {
+    dependencies = ["parser"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0gkf1p8yal38nlvdb39qaiy0gr85fxfr09j5dxh8qvrgpncpnk78";
+      type = "gem";
+    };
+    version = "1.4.1";
+  };
+  rubocop-packaging = {
+    dependencies = ["rubocop"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bzjd1077v96pyp62jg7s8ndxqbdhfnrdpdnmgi7h88xw22fp5xf";
+      type = "gem";
+    };
+    version = "0.5.1";
+  };
+  ruby-progressbar = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "02nmaw7yx9kl7rbaan5pl8x5nn0y4j5954mzrkzi9i3dhsrps4nc";
+      type = "gem";
+    };
+    version = "1.11.0";
+  };
+  unicode = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1v8kxmq9i85agjpl7pnl72688901xhs8wxhmj6lpy16a8xz3nzxk";
+      type = "gem";
+    };
+    version = "0.4.4.4";
+  };
+  unicode-display_width = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nlfck6z986fngp0r74maswmyb1rcksc8xc3mfpw9cj23c3s8zwn";
+      type = "gem";
+    };
+    version = "2.2.0";
+  };
+  xapian-ruby = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1z8arjkd0nlj6zv9in2sihmbwpbd17a10lsv7nwii7z0jjscyxpp";
+      type = "gem";
+    };
+    version = "1.4.18";
+  };
+}

--- a/contrib/nix/ruby2.4-shell.nix
+++ b/contrib/nix/ruby2.4-shell.nix
@@ -1,0 +1,23 @@
+let
+  pkgs = import (builtins.fetchGit {
+    url = "https://github.com/danc86/nixpkgs";
+    ref = "refs/heads/old-rubies-for-sup";
+    rev = "a19c3284e36dd21c032f3495afdc6f8919b59497";
+  }) {};
+  gems = pkgs.bundlerEnv {
+    name = "ruby2.4-gems-for-sup";
+    ruby = pkgs.ruby_2_4.override { useRailsExpress = false; };
+    gemfile = ./Gemfile;
+    lockfile = ./ruby2.4-Gemfile.lock;
+    gemset = ./ruby2.4-gemset.nix;
+    gemConfig = pkgs.defaultGemConfig // {
+      # Workaround: remove rake from nativeBuildInputs, otherwise it causes
+      # xapian-bindings to build against the default Ruby version
+      # instead of our chosen version.
+      xapian-ruby = attrs: pkgs.defaultGemConfig.xapian-ruby attrs // {
+        dependencies = [ "rake" ];
+        nativeBuildInputs = [ pkgs.pkg-config ];
+      };
+    };
+  };
+in pkgs.mkShell { nativeBuildInputs = [ gems gems.wrappedRuby pkgs.pandoc ]; }

--- a/contrib/nix/ruby2.5-Gemfile.lock
+++ b/contrib/nix/ruby2.5-Gemfile.lock
@@ -1,0 +1,81 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    chronic (0.10.2)
+    coderay (1.1.3)
+    gpgme (2.0.20)
+      mini_portile2 (~> 2.3)
+    highline (2.0.3)
+    locale (2.1.3)
+    lockfile (2.1.3)
+    method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
+    mini_portile2 (2.8.0)
+    minitest (5.16.2)
+    ncursesw (1.4.10)
+    optimist (3.0.1)
+    parallel (1.22.1)
+    parser (3.1.2.0)
+      ast (~> 2.4.1)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    regexp_parser (2.5.0)
+    rexml (3.2.5)
+    rmail (1.1.4)
+    rr (1.2.1)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.17.0)
+      parser (>= 3.1.1.0)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
+    ruby-progressbar (1.11.0)
+    unicode (0.4.4.4)
+    unicode-display_width (2.2.0)
+    xapian-ruby (1.4.18)
+
+PLATFORMS
+  aarch64-linux
+  x86_64-darwin-17
+  x86_64-darwin-18
+  x86_64-darwin-19
+  x86_64-darwin-20
+  x86_64-darwin-21
+  x86_64-darwin-22
+  x86_64-linux
+
+DEPENDENCIES
+  bundler (>= 1.3, < 3)
+  chronic
+  gpgme (>= 2.0.2)
+  highline
+  locale (~> 2.0)
+  lockfile
+  mime-types (> 2.0)
+  minitest (~> 5.5)
+  ncursesw (~> 1.4.0)
+  optimist
+  pry
+  rake
+  rmail (>= 1.1.2, < 2)
+  rr (~> 1.1)
+  rubocop-packaging
+  unicode (~> 0.4.4)
+  unicode-display_width
+  xapian-ruby (~> 1.2)
+
+BUNDLED WITH
+   2.2.20

--- a/contrib/nix/ruby2.5-gemset.nix
+++ b/contrib/nix/ruby2.5-gemset.nix
@@ -1,0 +1,309 @@
+{
+  ast = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04nc8x27hlzlrr5c2gn7mar4vdr0apw5xg22wp6m8dx3wqr04a0y";
+      type = "gem";
+    };
+    version = "2.4.2";
+  };
+  chronic = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1hrdkn4g8x7dlzxwb1rfgr8kw3bp4ywg5l4y4i9c2g5cwv62yvvn";
+      type = "gem";
+    };
+    version = "0.10.2";
+  };
+  coderay = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0jvxqxzply1lwp7ysn94zjhh57vc14mcshw1ygw14ib8lhc00lyw";
+      type = "gem";
+    };
+    version = "1.1.3";
+  };
+  gpgme = {
+    dependencies = ["mini_portile2"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xbgh9d8nbvsvyzqnd0mzhz0nr9hx4qn025kmz6d837lry4lc6gw";
+      type = "gem";
+    };
+    version = "2.0.20";
+  };
+  highline = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0yclf57n2j3cw8144ania99h1zinf8q3f5zrhqa754j6gl95rp9d";
+      type = "gem";
+    };
+    version = "2.0.3";
+  };
+  locale = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0997465kxvpxm92fiwc2b16l49mngk7b68g5k35ify0m3q0yxpdn";
+      type = "gem";
+    };
+    version = "2.1.3";
+  };
+  lockfile = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0dij3ijywylvfgrpi2i0k17f6w0wjhnjjw0k9030f54z56cz7jrr";
+      type = "gem";
+    };
+    version = "2.1.3";
+  };
+  method_source = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1pnyh44qycnf9mzi1j6fywd5fkskv3x7nmsqrrws0rjn5dd4ayfp";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  mime-types = {
+    dependencies = ["mime-types-data"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0ipw892jbksbxxcrlx9g5ljq60qx47pm24ywgfbyjskbcl78pkvb";
+      type = "gem";
+    };
+    version = "3.4.1";
+  };
+  mime-types-data = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "003gd7mcay800k2q4pb2zn8lwwgci4bhi42v2jvlidm8ksx03i6q";
+      type = "gem";
+    };
+    version = "3.2022.0105";
+  };
+  mini_portile2 = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rapl1sfmfi3bfr68da4ca16yhc0pp93vjwkj7y3rdqrzy3b41hy";
+      type = "gem";
+    };
+    version = "2.8.0";
+  };
+  minitest = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "14a9ign0hj3z3j4cpfplj2djaskx3skzyx4fl3x53d7saxmhrgn1";
+      type = "gem";
+    };
+    version = "5.16.2";
+  };
+  ncursesw = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nc14wls1yiigz593vw7580hb99lf4n485axapiz6sqpg1jnlhcr";
+      type = "gem";
+    };
+    version = "1.4.10";
+  };
+  optimist = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vg2chy1cfmdj6c1gryl8zvjhhmb3plwgyh1jfnpq4fnfqv7asrk";
+      type = "gem";
+    };
+    version = "3.0.1";
+  };
+  parallel = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "07vnk6bb54k4yc06xnwck7php50l09vvlw1ga8wdz0pia461zpzb";
+      type = "gem";
+    };
+    version = "1.22.1";
+  };
+  parser = {
+    dependencies = ["ast"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xhfghgidj8cbdnqp01f7kvnrv1f60izpkd9dhxsvpdzkfsdg97d";
+      type = "gem";
+    };
+    version = "3.1.2.0";
+  };
+  pry = {
+    dependencies = ["coderay" "method_source"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0m445x8fwcjdyv2bc0glzss2nbm1ll51bq45knixapc7cl3dzdlr";
+      type = "gem";
+    };
+    version = "0.14.1";
+  };
+  rainbow = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0smwg4mii0fm38pyb5fddbmrdpifwv22zv3d3px2xx497am93503";
+      type = "gem";
+    };
+    version = "3.1.1";
+  };
+  rake = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "15whn7p9nrkxangbs9hh75q585yfn66lv0v2mhj6q6dl6x8bzr2w";
+      type = "gem";
+    };
+    version = "13.0.6";
+  };
+  regexp_parser = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1rfd3q17p7q7pa67844q8b16ipy6ksh8mkzynpm1zldqbb9x4xm0";
+      type = "gem";
+    };
+    version = "2.5.0";
+  };
+  rexml = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "08ximcyfjy94pm1rhcx04ny1vx2sk0x4y185gzn86yfsbzwkng53";
+      type = "gem";
+    };
+    version = "3.2.5";
+  };
+  rmail = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0m5npkmv764m725wzjzasgf3k8q5anf3vfr6k2cac1xj6jc8lcqi";
+      type = "gem";
+    };
+    version = "1.1.4";
+  };
+  rr = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1n9g78ba4c2zzmz8cdb97c38h1xm0clircag00vbcxwqs4dq0ymp";
+      type = "gem";
+    };
+    version = "1.2.1";
+  };
+  rubocop = {
+    dependencies = ["parallel" "parser" "rainbow" "regexp_parser" "rexml" "rubocop-ast" "ruby-progressbar" "unicode-display_width"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xxkghaph53200mfria115swdq6j7p5ssc6gqr1xwvnqiw8g96qd";
+      type = "gem";
+    };
+    version = "1.28.2";
+  };
+  rubocop-ast = {
+    dependencies = ["parser"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1k9izkr5rhw3zc309yjp17z7496l74j4li3zrcgpgqfnqwz695qx";
+      type = "gem";
+    };
+    version = "1.17.0";
+  };
+  rubocop-packaging = {
+    dependencies = ["rubocop"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bzjd1077v96pyp62jg7s8ndxqbdhfnrdpdnmgi7h88xw22fp5xf";
+      type = "gem";
+    };
+    version = "0.5.1";
+  };
+  ruby-progressbar = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "02nmaw7yx9kl7rbaan5pl8x5nn0y4j5954mzrkzi9i3dhsrps4nc";
+      type = "gem";
+    };
+    version = "1.11.0";
+  };
+  unicode = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1v8kxmq9i85agjpl7pnl72688901xhs8wxhmj6lpy16a8xz3nzxk";
+      type = "gem";
+    };
+    version = "0.4.4.4";
+  };
+  unicode-display_width = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nlfck6z986fngp0r74maswmyb1rcksc8xc3mfpw9cj23c3s8zwn";
+      type = "gem";
+    };
+    version = "2.2.0";
+  };
+  xapian-ruby = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1z8arjkd0nlj6zv9in2sihmbwpbd17a10lsv7nwii7z0jjscyxpp";
+      type = "gem";
+    };
+    version = "1.4.18";
+  };
+}

--- a/contrib/nix/ruby2.5-shell.nix
+++ b/contrib/nix/ruby2.5-shell.nix
@@ -1,0 +1,23 @@
+let
+  pkgs = import (builtins.fetchGit {
+    url = "https://github.com/danc86/nixpkgs";
+    ref = "refs/heads/old-rubies-for-sup";
+    rev = "a19c3284e36dd21c032f3495afdc6f8919b59497";
+  }) {};
+  gems = pkgs.bundlerEnv {
+    name = "ruby2.5-gems-for-sup";
+    ruby = pkgs.ruby_2_5.override { useRailsExpress = false; };
+    gemfile = ./Gemfile;
+    lockfile = ./ruby2.5-Gemfile.lock;
+    gemset = ./ruby2.5-gemset.nix;
+    gemConfig = pkgs.defaultGemConfig // {
+      # Workaround: remove rake from nativeBuildInputs, otherwise it causes
+      # xapian-bindings to build against the default Ruby version
+      # instead of our chosen version.
+      xapian-ruby = attrs: pkgs.defaultGemConfig.xapian-ruby attrs // {
+        dependencies = [ "rake" ];
+        nativeBuildInputs = [ pkgs.pkg-config ];
+      };
+    };
+  };
+in pkgs.mkShell { nativeBuildInputs = [ gems gems.wrappedRuby pkgs.pandoc ]; }

--- a/contrib/nix/ruby2.6-shell.nix
+++ b/contrib/nix/ruby2.6-shell.nix
@@ -1,0 +1,23 @@
+let
+  pkgs = import (builtins.fetchGit {
+    url = "https://github.com/NixOS/nixpkgs";
+    ref = "refs/heads/master";
+    rev = "3ef1d2a9602c18f8742e1fb63d5ae9867092e3d6";
+  }) {};
+  gems = pkgs.bundlerEnv {
+    name = "ruby2.6-gems-for-sup";
+    ruby = pkgs.ruby_2_6;
+    gemfile = ./Gemfile;
+    lockfile = ./Gemfile.lock;
+    gemset = ./gemset.nix;
+    gemConfig = pkgs.defaultGemConfig // {
+      # Workaround: remove rake from nativeBuildInputs, otherwise it causes
+      # xapian-bindings to build against the default Ruby version
+      # instead of our chosen version.
+      xapian-ruby = attrs: pkgs.defaultGemConfig.xapian-ruby attrs // {
+        dependencies = [ "rake" ];
+        nativeBuildInputs = [ pkgs.pkg-config ];
+      };
+    };
+  };
+in pkgs.mkShell { packages = [ gems gems.wrappedRuby pkgs.pandoc ]; }

--- a/contrib/nix/ruby2.7-shell.nix
+++ b/contrib/nix/ruby2.7-shell.nix
@@ -1,0 +1,14 @@
+let
+  pkgs = import (builtins.fetchGit {
+    url = "https://github.com/NixOS/nixpkgs";
+    ref = "refs/heads/master";
+    rev = "f5ffd5787786dde3a8bf648c7a1b5f78c4e01abb";
+  }) {};
+  gems = pkgs.bundlerEnv {
+    name = "ruby2.7-gems-for-sup";
+    ruby = pkgs.ruby_2_7;
+    gemfile = ./Gemfile;
+    lockfile = ./Gemfile.lock;
+    gemset = ./gemset.nix;
+  };
+in pkgs.mkShell { packages = [ gems gems.wrappedRuby pkgs.pandoc ]; }

--- a/contrib/nix/ruby3.0-shell.nix
+++ b/contrib/nix/ruby3.0-shell.nix
@@ -1,0 +1,14 @@
+let
+  pkgs = import (builtins.fetchGit {
+    url = "https://github.com/NixOS/nixpkgs";
+    ref = "refs/heads/master";
+    rev = "f5ffd5787786dde3a8bf648c7a1b5f78c4e01abb";
+  }) {};
+  gems = pkgs.bundlerEnv {
+    name = "ruby3.0-gems-for-sup";
+    ruby = pkgs.ruby_3_0;
+    gemfile = ./Gemfile;
+    lockfile = ./Gemfile.lock;
+    gemset = ./gemset.nix;
+  };
+in pkgs.mkShell { packages = [ gems gems.wrappedRuby pkgs.pandoc ]; }

--- a/contrib/nix/ruby3.1-shell.nix
+++ b/contrib/nix/ruby3.1-shell.nix
@@ -1,0 +1,14 @@
+let
+  pkgs = import (builtins.fetchGit {
+    url = "https://github.com/NixOS/nixpkgs";
+    ref = "refs/heads/master";
+    rev = "f5ffd5787786dde3a8bf648c7a1b5f78c4e01abb";
+  }) {};
+  gems = pkgs.bundlerEnv {
+    name = "ruby3.1-gems-for-sup";
+    ruby = pkgs.ruby_3_1;
+    gemfile = ./Gemfile;
+    lockfile = ./Gemfile.lock;
+    gemset = ./gemset.nix;
+  };
+in pkgs.mkShell { packages = [ gems gems.wrappedRuby pkgs.pandoc ]; }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+contrib/nix/ruby3.1-shell.nix


### PR DESCRIPTION
I was fed up with having no way to test on older Ruby versions locally. And I had no way to debug the Homebrew stuff on MacOS which seems to be currently failing in our CI. So I set up Nix for proper, reproducible environments.