### PR TITLE
fix compatibility with Xapian 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,7 @@ source 'https://rubygems.org/'
 
 if !RbConfig::CONFIG['arch'].include?('openbsd')
   # update version in ext/mkrf_conf_xapian.rb as well.
-  if /^2\.0\./ =~ RUBY_VERSION
-    gem 'xapian-ruby', ['~> 1.2', '< 1.3.6']
-  else
-    gem 'xapian-ruby', '~> 1.2'
-  end
+  gem 'xapian-ruby', '~> 1.4'
 end
 
 gemspec

--- a/contrib/nix/Gemfile
+++ b/contrib/nix/Gemfile
@@ -11,7 +11,6 @@ gem "locale", "~> 2.0"
 gem "chronic"
 gem "unicode", "~> 0.4.4"
 gem "unicode-display_width"
-gem "string-scrub" if /^2\.0\./ =~ RUBY_VERSION
 gem "benchmark"
 gem "fiddle"
 

--- a/contrib/nix/Gemfile
+++ b/contrib/nix/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org/"
 
-gem "xapian-ruby", "~> 1.2"
+gem "xapian-ruby", "~> 1.4"
 gem "ncursesw", "~> 1.4.0"
 gem "rmail", ">= 1.1.2", "< 2"
 gem "highline"

--- a/contrib/nix/Gemfile.lock
+++ b/contrib/nix/Gemfile.lock
@@ -95,7 +95,7 @@ DEPENDENCIES
   rubocop-packaging
   unicode (~> 0.4.4)
   unicode-display_width
-  xapian-ruby (~> 1.2)
+  xapian-ruby (~> 1.4)
 
 BUNDLED WITH
    2.5.22

--- a/contrib/nix/ruby2.4-Gemfile.lock
+++ b/contrib/nix/ruby2.4-Gemfile.lock
@@ -79,7 +79,7 @@ DEPENDENCIES
   rubocop-packaging
   unicode (~> 0.4.4)
   unicode-display_width
-  xapian-ruby (~> 1.2)
+  xapian-ruby (~> 1.4)
 
 BUNDLED WITH
    2.2.20

--- a/contrib/nix/ruby2.5-Gemfile.lock
+++ b/contrib/nix/ruby2.5-Gemfile.lock
@@ -79,7 +79,7 @@ DEPENDENCIES
   rubocop-packaging
   unicode (~> 0.4.4)
   unicode-display_width
-  xapian-ruby (~> 1.2)
+  xapian-ruby (~> 1.4)
 
 BUNDLED WITH
    2.2.20

--- a/contrib/nix/ruby2.6-Gemfile.lock
+++ b/contrib/nix/ruby2.6-Gemfile.lock
@@ -81,7 +81,7 @@ DEPENDENCIES
   rubocop-packaging
   unicode (~> 0.4.4)
   unicode-display_width
-  xapian-ruby (~> 1.2)
+  xapian-ruby (~> 1.4)
 
 BUNDLED WITH
    2.3.9

--- a/contrib/nix/ruby2.7-Gemfile.lock
+++ b/contrib/nix/ruby2.7-Gemfile.lock
@@ -85,7 +85,7 @@ DEPENDENCIES
   rubocop-packaging
   unicode (~> 0.4.4)
   unicode-display_width
-  xapian-ruby (~> 1.2)
+  xapian-ruby (~> 1.4)
 
 BUNDLED WITH
    2.4.22

--- a/contrib/nix/ruby3.0-Gemfile.lock
+++ b/contrib/nix/ruby3.0-Gemfile.lock
@@ -85,7 +85,7 @@ DEPENDENCIES
   rubocop-packaging
   unicode (~> 0.4.4)
   unicode-display_width
-  xapian-ruby (~> 1.2)
+  xapian-ruby (~> 1.4)
 
 BUNDLED WITH
    2.4.22

--- a/ext/mkrf_conf_xapian.rb
+++ b/ext/mkrf_conf_xapian.rb
@@ -17,12 +17,7 @@ begin
   if not ENV.include? "SUP_SKIP_XAPIAN_GEM_INSTALL"
     # update version in Gemfile as well
     name    = "xapian-ruby"
-    version =
-      if /^2\.0\./ =~ RUBY_VERSION
-        ["~> 1.2", "< 1.3.6"]
-      else
-        "~> 1.2"
-      end
+    version = "~> 1.4"
 
     begin
       # try to load gem

--- a/lib/sup/index.rb
+++ b/lib/sup/index.rb
@@ -13,10 +13,10 @@ require "sup/hook"
 require "sup/logger/singleton"
 
 
-if ([Xapian.major_version, Xapian.minor_version, Xapian.revision] <=> [1,2,15]) < 0
+if ([Xapian.major_version, Xapian.minor_version, Xapian.revision] <=> [1,4,0]) < 0
   fail <<-EOF
 \n
-Xapian version 1.2.15 or higher required.
+Xapian version 1.4.0 or higher required.
 If you have xapian-full-alaveteli installed,
 Please remove it by running `gem uninstall xapian-full-alaveteli`
 since it's been replaced by the xapian-ruby gem.
@@ -142,7 +142,7 @@ EOS
 
   def save_index
     info "Flushing Xapian updates to disk. This may take a while..."
-    @xapian.flush
+    @xapian.commit
   end
 
   def contains_id? id
@@ -516,9 +516,8 @@ EOS
     qp.stemmer = Xapian::Stem.new($config[:stem_language])
     qp.stemming_strategy = Xapian::QueryParser::STEM_SOME
     qp.default_op = Xapian::Query::OP_AND
-    valuerangeprocessor = Xapian::NumberValueRangeProcessor.new(DATE_VALUENO,
-                                                                'date:', true)
-    qp.add_valuerangeprocessor(valuerangeprocessor)
+    rangeprocessor = Xapian::NumberRangeProcessor.new(DATE_VALUENO, 'date:')
+    qp.add_rangeprocessor(rangeprocessor)
     NORMAL_PREFIX.each { |k,info| info[:prefix].each {
       |v| qp.add_prefix k, v }
     }

--- a/lib/sup/message.rb
+++ b/lib/sup/message.rb
@@ -1,7 +1,6 @@
 # encoding: UTF-8
 
 require 'time'
-require 'string-scrub' if /^2\.0\./ =~ RUBY_VERSION
 
 module Redwood
 

--- a/lib/sup/message_chunks.rb
+++ b/lib/sup/message_chunks.rb
@@ -35,29 +35,6 @@ require 'shellwords'
 ## included as quoted text during a reply. Text, Quotes, and mime-parsed
 ## attachments are quotable; Signatures are not.
 
-## monkey-patch time: make temp files have the right extension
-## Backport from Ruby 1.9.2 for versions lower than 1.8.7
-if RUBY_VERSION < '1.8.7'
-  class Tempfile
-    def make_tmpname(prefix_suffix, n)
-      case prefix_suffix
-      when String
-        prefix = prefix_suffix
-        suffix = ""
-      when Array
-        prefix = prefix_suffix[0]
-        suffix = prefix_suffix[1]
-      else
-        raise ArgumentError, "unexpected prefix_suffix: #{prefix_suffix.inspect}"
-      end
-      t = Time.now.strftime("%Y%m%d")
-      path = "#{prefix}#{t}-#{$$}-#{rand(0x100000000).to_s(36)}"
-      path << "-#{n}" if n
-      path << suffix
-    end
-  end
-end
-
 
 module Redwood
 module Chunk

--- a/lib/sup/util.rb
+++ b/lib/sup/util.rb
@@ -11,7 +11,6 @@ require 'benchmark'
 require 'unicode'
 require 'unicode/display_width'
 require 'fileutils'
-require 'string-scrub' if /^2\.0\./ =~ RUBY_VERSION
 
 module ExtendedLockfile
   def gen_lock_id

--- a/sup.gemspec
+++ b/sup.gemspec
@@ -38,7 +38,7 @@ SUP: please note that our old mailing lists have been shut down,
   s.require_paths = ["lib"]
   s.extra_rdoc_files = Dir.glob("man/*")
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.1.0'
 
   # this is here to support skipping the xapian-ruby installation on OpenBSD
   # because the xapian-ruby gem doesn't install on OpenBSD, you must install

--- a/sup.gemspec
+++ b/sup.gemspec
@@ -60,7 +60,6 @@ SUP: please note that our old mailing lists have been shut down,
   s.add_runtime_dependency "chronic"
   s.add_runtime_dependency "unicode", "~> 0.4.4"
   s.add_runtime_dependency "unicode-display_width"
-  s.add_runtime_dependency "string-scrub" if /^2\.0\./ =~ RUBY_VERSION
   s.add_runtime_dependency "benchmark"
   s.add_runtime_dependency "fiddle"
 

--- a/test/unit/util/test_query.rb
+++ b/test/unit/util/test_query.rb
@@ -24,15 +24,8 @@ describe Redwood::Util::Query do
       query = Xapian::Query.new msg
       life = 'hæi'
 
-      if query.description.force_encoding("UTF-8").valid_encoding?
-        # xapian 1.4 internally handles this bad input
-        assert true
-      else
-        # xapian 1.2 doesn't handle this bad input, so we do
-        assert_raises Redwood::Util::Query::QueryDescriptionError do
-          _desc = Redwood::Util::Query.describe (query)
-        end
-      end
+      # xapian 1.4 internally handles this bad input
+      assert query.description.force_encoding("UTF-8").valid_encoding?
 
       assert_raises Encoding::CompatibilityError do
         _ = life + query.description


### PR DESCRIPTION
The updated code still works with Xapian 1.4.x, but not Xapian 1.2.x. Xapian 1.2.x is long unsupported (final release was 2017-09-26) so make 1.4.0 the minimum requirement.  Xapian 1.4.0 requires Ruby 2.1 which also seems unlikely to be controversial so require that too.